### PR TITLE
add collapsible two-level menu for mobile layout

### DIFF
--- a/ote/src/cljs/ote/app/controller/front_page.cljs
+++ b/ote/src/cljs/ote/app/controller/front_page.cljs
@@ -15,6 +15,7 @@
 (defrecord OpenNewTab [url])
 (defrecord StayOnPage [])
 (defrecord ToggleFintrafficMenu [])
+(defrecord ToggleMobileBottomMenu [])
 (defrecord ToggleUpdatesMenu [])
 (defrecord ToggleServiceInfoMenu [])
 (defrecord ToggleMyServicesMenu [])
@@ -119,6 +120,14 @@
   (process-event [_ app]
     (toggle-menu app [:ote-service-flags :fintraffic-menu-open]))
 
+  ToggleMobileBottomMenu
+  (process-event [_ app]
+    ; mobile bottom menu is handled separately to support two-level nested menus
+    (assoc-in
+      app
+      [:ote-service-flags :mobile-bottom-menu-open]
+      (if (get-in app [:ote-service-flags :mobile-bottom-menu-open]) false true)))
+
   ToggleUpdatesMenu
   (process-event [_ app]
     (toggle-menu app [:ote-service-flags :navigation-updates-menu]))
@@ -145,7 +154,10 @@
 
   CloseHeaderMenus
   (process-event [_ app]
-    (close-all-menus app))
+    (-> app
+        (close-all-menus)
+        ; mobile bottom menu is handled separately to support two-level nested menus
+        (assoc-in [:ote-service-flags :mobile-bottom-menu-open] false)))
 
   Logout
   (process-event [_ app]

--- a/ote/src/cljs/ote/style/topnav.cljs
+++ b/ote/src/cljs/ote/style/topnav.cljs
@@ -46,7 +46,9 @@
                        :justify-content "flex-start"
                        :min-height "56px"
                        ::stylefy/media {{:max-width (str width-sm "px")} {:flex-direction "column"
-                                                                          :padding "0"}}})
+                                                                          :padding-left "1rem"
+                                                                          :padding-right "1rem"
+                                                                          :min-height "unset"}}})
 
 (def nap-menu {:height "100%"
                :width "100%"})
@@ -74,15 +76,23 @@
                             ::stylefy/media {{:max-width (str width-sm "px")} {:width "100%"
                                                                                :text-align "left"
                                                                                :line-height "1.5"
-                                                                               :padding ".5em 1em .5em 1em"}}})
+                                                                               :padding ".5em 0em .5em 0em"}}})
 
-(def bottombar-left-aligned-items {:display "flex"
-                                   ::stylefy/media {{:max-width (str width-sm "px")} {:display "block"}}})
+(def bottombar-frontpage-label {:margin-right ".5rem"
+                                ::stylefy/media {{:max-width (str width-sm "px")} {:width "100%"
+                                                                                   :text-align "left"
+                                                                                   :line-height "1.5"
+                                                                                   :padding ".5em 0em .5em 0em"}}})
+
+(def bottombar-left-aligned-items {:display "flex"})
 
 (def bottombar-right-aligned-items {:display "flex"
                                     :margin-left "auto"
-                                    ::stylefy/media {{:max-width (str width-sm "px")} {:display "block"
-                                                                                       :margin "unset"}}})
+                                    ::stylefy/media {{:max-width (str width-sm "px")} {:margin "unset"}}})
+
+(def bottombar-mobile-menu {:display "flex"
+                            :margin-left "auto"
+                            :color "#000"})
 
 (def bottombar-spacer {:margin-right "1.2rem"
                        ::stylefy/media {{:max-width (str width-sm "px")} {:display "none"}}})
@@ -98,15 +108,17 @@
                                                                                   :border "none"}}})
 
 (def bottombar-dropdown-item {:border-bottom "1px solid #ddd"
-                                  :display "block"
-                                  :margin-right "0"
-                                  :white-space "nowrap"})
+                              :display "block"
+                              :margin-right "0"
+                              :white-space "nowrap"
+                              ::stylefy/media {{:max-width (str width-sm "px")} {:border "unset"}}})
 
 (def bottombar-dropdown-link {:display "block"
-                                  :padding ".5rem 1rem"
-                                  :transition "color .15s ease-out"
-                                  :color "#000"
-                                  :text-decoration "none"})
+                              :padding ".5rem 1rem"
+                              :transition "color .15s ease-out"
+                              :color "#000"
+                              :text-decoration "none"
+                              ::stylefy/media {{:max-width (str width-sm "px")} {:padding ".5rem 0rem"}}})
 
 (def fintraffic-logo-link {:align-self "center"
                            :display "inline-flex"
@@ -152,6 +164,9 @@
                                    :cursor "pointer"
                                    :height "100%"
                                    :border "0"})
+
+(def bottombar-mobile-nav-button (merge fintraffic-mobile-nav-button
+                                        {:color "#000"}))
 
 (def style {:content ""})
 

--- a/ote/src/cljs/ote/ui/main_header.cljs
+++ b/ote/src/cljs/ote/ui/main_header.cljs
@@ -154,149 +154,174 @@
   [:span (stylefy/use-style style-topnav/bottombar-spacer)])
 
 (defn nap-bottombar [e! app desktop?]
+  (let [menu-open? (get-in app [:ote-service-flags :mobile-bottom-menu-open])]
+    [:div (stylefy/use-style style-topnav/header-bottombar)
+     ; frontpage link has its own container to keep it always visible
+     [:span (stylefy/use-style style-topnav/bottombar-left-aligned-items)
+      [:div (stylefy/use-style {:align-self "center"})
+       [:button (merge (stylefy/use-style style-topnav/bottombar-entry-button)
+                       {:on-click #(do (routes/navigate! :front-page)
+                                       (e! (fp-controller/->CloseHeaderMenus)))})
+        ; label
+        [:span (stylefy/use-style (merge style-topnav/bottombar-frontpage-label
+                                         {:font-weight "800"}))
+         "NAP"]
+        ]]
 
-  [:div (stylefy/use-style style-topnav/header-bottombar)
-   ; left grouped entries
-   [:span (stylefy/use-style style-topnav/bottombar-left-aligned-items)
+      ; mobile only right aligned menu toggle button
+      [:span (stylefy/use-style style-topnav/bottombar-mobile-menu)
+       [:button (merge (stylefy/use-style (merge style-topnav/mobile-only
+                                                 style-topnav/bottombar-mobile-nav-button))
+                       {:on-click #(e! (fp-controller/->ToggleMobileBottomMenu))})
+        [:span {:style {:font-weight 600 :align-self "center"}} (tr [:common-texts :navigation-general-menu])]  ; TODO: translations
+        [feather-icons/menu
+         (stylefy/use-style style-topnav/bottombar-entry-icon)]]]]
 
-    [bottombar-simplelink e! app {:label              "NAP"
-                                  :label-styles       {:font-weight "800"}
-                                  :menu-click-handler #(do (routes/navigate! :front-page)
-                                                           (e! (fp-controller/->CloseHeaderMenus)))}]
+     ; left grouped entries
+     [:span (stylefy/use-style (merge style-topnav/bottombar-left-aligned-items
+                                      (when (not desktop?)
+                                        (if menu-open?
+                                          {:display "block"}
+                                          {:display "none"}))))
 
-    [bottombar-spacer]
+      [bottombar-spacer]
 
-    [bottombar-dropdown e! app desktop? {:tag     :updates
-                                         :entries             [{:key   :updates
-                                                                :label (tr [:common-texts :updates-menu-updates])}]
-                                         :label               (tr [:common-texts :navigation-updates-menu])
-                                         :state-flag          [:ote-service-flags :navigation-updates-menu]
-                                         :menu-click-handler  #(e! (fp-controller/->ToggleUpdatesMenu))
-                                         :entry-click-handler identity}]
+      [bottombar-dropdown e! app desktop? {:tag     :updates
+                                           :entries             [{:key   :updates
+                                                                  :label (tr [:common-texts :updates-menu-updates])}]
+                                           :label               (tr [:common-texts :navigation-updates-menu])
+                                           :state-flag          [:ote-service-flags :navigation-updates-menu]
+                                           :menu-click-handler  #(e! (fp-controller/->ToggleUpdatesMenu))
+                                           :entry-click-handler identity}]
 
-    [bottombar-spacer]
+      [bottombar-spacer]
 
-    [bottombar-dropdown e! app desktop? {:tag                 :service-info
-                                         :entries             [{:key :ohjeet
-                                                                :label (tr [:common-texts :user-menu-nap-help])
-                                                                :href (tr [:common-texts :user-menu-nap-help-link])
-                                                                :target "_blank"}
-                                                               {:key :rajapinta
-                                                                :label (tr [:common-texts :navigation-for-developers])
-                                                                :href "https://github.com/finnishtransportagency/mmtis-national-access-point/blob/master/docs/api/README.md"
-                                                                :target "_blank"}
-                                                               (when (flags/enabled? :terms-of-service)
-                                                                 {:key :käyttöehdot
-                                                                  :label (tr [:common-texts :navigation-terms-of-service-text])
-                                                                  :href (tr [:common-texts :navigation-terms-of-service-url])
-                                                                  :target "_blank"})
-                                                               {:key :tietosuojaseloste
-                                                                :label (tr [:common-texts :navigation-privacy-policy])
-                                                                :href (tr [:common-texts :navigation-privacy-policy-url])
-                                                                :target "_blank"}]
-                                         :label               (tr [:common-texts :navigation-service-info-menu])
-                                         :state-flag          [:ote-service-flags :service-info-menu-open]
-                                         :menu-click-handler  #(e! (fp-controller/->ToggleServiceInfoMenu))
-                                         :entry-click-handler identity}]
+      [bottombar-dropdown e! app desktop? {:tag                 :service-info
+                                           :entries             [{:key :ohjeet
+                                                                  :label (tr [:common-texts :user-menu-nap-help])
+                                                                  :href (tr [:common-texts :user-menu-nap-help-link])
+                                                                  :target "_blank"}
+                                                                 {:key :rajapinta
+                                                                  :label (tr [:common-texts :navigation-for-developers])
+                                                                  :href "https://github.com/finnishtransportagency/mmtis-national-access-point/blob/master/docs/api/README.md"
+                                                                  :target "_blank"}
+                                                                 (when (flags/enabled? :terms-of-service)
+                                                                   {:key :käyttöehdot
+                                                                    :label (tr [:common-texts :navigation-terms-of-service-text])
+                                                                    :href (tr [:common-texts :navigation-terms-of-service-url])
+                                                                    :target "_blank"})
+                                                                 {:key :tietosuojaseloste
+                                                                  :label (tr [:common-texts :navigation-privacy-policy])
+                                                                  :href (tr [:common-texts :navigation-privacy-policy-url])
+                                                                  :target "_blank"}]
+                                           :label               (tr [:common-texts :navigation-service-info-menu])
+                                           :state-flag          [:ote-service-flags :service-info-menu-open]
+                                           :menu-click-handler  #(e! (fp-controller/->ToggleServiceInfoMenu))
+                                           :entry-click-handler identity}]
 
-    [bottombar-spacer]
-    [bottombar-dropdown e! app desktop? {:tag                 :support
-                                         :entries             [{:key :channels
-                                                                :label (tr [:common-texts :support-menu-channels])}
-                                                               {:key :contacts
-                                                                :label (tr [:common-texts :support-menu-contacts])}]
-                                         :label               (tr [:common-texts :navigation-support-menu])
-                                         :state-flag          [:ote-service-flags :support-menu-open]
-                                         :menu-click-handler  #(e! (fp-controller/->ToggleSupportMenu))
-                                         :entry-click-handler identity}]
+      [bottombar-spacer]
+      [bottombar-dropdown e! app desktop? {:tag                 :support
+                                           :entries             [{:key :channels
+                                                                  :label (tr [:common-texts :support-menu-channels])}
+                                                                 {:key :contacts
+                                                                  :label (tr [:common-texts :support-menu-contacts])}]
+                                           :label               (tr [:common-texts :navigation-support-menu])
+                                           :state-flag          [:ote-service-flags :support-menu-open]
+                                           :menu-click-handler  #(e! (fp-controller/->ToggleSupportMenu))
+                                           :entry-click-handler identity}]
 
-    [bottombar-spacer]
+      [bottombar-spacer]
 
-    (if (user-logged-in? app)
-      [bottombar-dropdown e! app desktop? {:tag                 :my-services
-                                           :entries             [{:key :services
-                                                                  :label (tr [:document-title :services])
-                                                                  :href "#/services"}
-                                                                 {:key :own-services
-                                                                  :label (tr [:document-title :own-services])
-                                                                  :href "#/own-services"}
-                                                                 {:key :routes
-                                                                  :label (tr [:common-texts :navigation-route])
-                                                                  :href "#/routes"}
-                                                                 {:key :pre-notices
-                                                                  :label (tr [:common-texts :navigation-pre-notice])
-                                                                  :href "#/pre-notices"}
-                                                                 {:key :authority-pre-notices
-                                                                  :label (tr [:common-texts :navigation-authority-pre-notices])
-                                                                  :href "#/authority-pre-notices"}
-                                                                 {:key :admin
-                                                                  :label (tr [:document-title :admin])
-                                                                  :href "#/admin"}
-                                                                 {:key :monitor
-                                                                  :label (tr [:document-title :monitor])
-                                                                  :href "#/monitor"}]
-                                           :label               (tr [:common-texts :navigation-my-services-menu])
-                                           :state-flag          [:ote-service-flags :my-services-menu-open]
-                                           :menu-click-handler  #(e! (fp-controller/->ToggleMyServicesMenu))
+      (if (user-logged-in? app)
+        [bottombar-dropdown e! app desktop? {:tag                 :my-services
+                                             :entries             [{:key :services
+                                                                    :label (tr [:document-title :services])
+                                                                    :href "#/services"}
+                                                                   {:key :own-services
+                                                                    :label (tr [:document-title :own-services])
+                                                                    :href "#/own-services"}
+                                                                   {:key :routes
+                                                                    :label (tr [:common-texts :navigation-route])
+                                                                    :href "#/routes"}
+                                                                   {:key :pre-notices
+                                                                    :label (tr [:common-texts :navigation-pre-notice])
+                                                                    :href "#/pre-notices"}
+                                                                   {:key :authority-pre-notices
+                                                                    :label (tr [:common-texts :navigation-authority-pre-notices])
+                                                                    :href "#/authority-pre-notices"}
+                                                                   {:key :admin
+                                                                    :label (tr [:document-title :admin])
+                                                                    :href "#/admin"}
+                                                                   {:key :monitor
+                                                                    :label (tr [:document-title :monitor])
+                                                                    :href "#/monitor"}]
+                                             :label               (tr [:common-texts :navigation-my-services-menu])
+                                             :state-flag          [:ote-service-flags :my-services-menu-open]
+                                             :menu-click-handler  #(e! (fp-controller/->ToggleMyServicesMenu))
+                                             :entry-click-handler (fn [e entry]
+                                                                    (routes/navigate! (:key entry))
+                                                                    (e! (fp-controller/->ToggleMyServicesMenu)))}]
+        [bottombar-simplelink e! app {:label              (tr [:document-title :services])
+                                      :href               "#/services"
+                                      :menu-click-handler #(do (routes/navigate! :services)
+                                                               (e! (fp-controller/->CloseHeaderMenus)))}])
+     ]
+
+     ; right aligned entries
+     [:span (stylefy/use-style (merge style-topnav/bottombar-right-aligned-items
+                                      (when (not desktop?)
+                                        (if menu-open?
+                                          {:display "block"}
+                                          {:display "none"}))))
+      (when (user-logged-in? app)
+        [bottombar-dropdown e! app desktop? {:tag                 :user-details
+                                             :entries             [{:key   :Sähköposti-ilmoitusten-asetukset
+                                                                    :label (tr [:common-texts :navigation-email-notification-settings])
+                                                                    :href  "#/email-settings"}
+                                                                   {:key   :Käyttäjätilin-muokkaus
+                                                                    :label (tr [:common-texts :user-menu-profile])
+                                                                    :href "#/user"}
+                                                                   {:key   :Kirjaudu-ulos
+                                                                    :label (tr [:common-texts :user-menu-log-out])}]
+                                             :label               (get-in app [:user :name])
+                                             :prefix-icon         feather-icons/user
+                                             :state-flag          [:ote-service-flags :user-menu-open]
+                                             :menu-click-handler  #(e! (fp-controller/->ToggleUserMenu))
+                                             :entry-click-handler (fn [e entry]
+                                                                    (when (= (:key entry) :Kirjaudu-ulos)
+                                                                      (.preventDefault e)
+                                                                      (e! (fp-controller/->ToggleUserMenu))
+                                                                      (e! (login/->Logout))))}])
+      ; reagent version in this project is so old that it doesn't support fragments ([:<>]) so have to do these three
+      ; like so...
+      (when (and (not (user-logged-in? app))
+                 (flags/enabled? :ote-login))
+        [bottombar-simplelink e! app {:label              (tr [:common-texts :navigation-login])
+                                      :menu-click-handler #(e! (login/->ShowLoginPage))}])
+
+      (when (not (user-logged-in? app)) [bottombar-spacer])
+
+      (when (not (user-logged-in? app))
+        [bottombar-simplelink e! app {:label              (tr [:common-texts :navigation-register])
+                                      :menu-click-handler #(e! (fp-controller/->ToggleRegistrationDialog))}])
+
+      [bottombar-spacer]
+
+      [bottombar-dropdown e! app desktop? {:tag                 :language-selector
+                                           :entries             [{:key "fi"
+                                                                  :label "Suomeksi"}
+                                                                 {:key "sv"
+                                                                  :label "På Svenska"}
+                                                                 {:key "en"
+                                                                  :label "In English"}]
+                                           :label               (get-lang-label @localization/selected-language)
+                                           :prefix-icon         feather-icons/globe
+                                           :state-flag          [:ote-service-flags :lang-menu-open]
+                                           :menu-click-handler  #(e! (fp-controller/->ToggleLangMenu))
                                            :entry-click-handler (fn [e entry]
-                                                                  (routes/navigate! (:key entry))
-                                                                  (e! (fp-controller/->ToggleMyServicesMenu)))}]
-      [bottombar-simplelink e! app {:label              (tr [:document-title :services])
-                                    :href               "#/services"
-                                    :menu-click-handler #(do (routes/navigate! :services)
-                                                             (e! (fp-controller/->CloseHeaderMenus)))}])
-   ]
-   ; right aligned entries
-   [:span (stylefy/use-style style-topnav/bottombar-right-aligned-items)
-    (when (user-logged-in? app)
-      [bottombar-dropdown e! app desktop? {:tag                 :user-details
-                                           :entries             [{:key   :Sähköposti-ilmoitusten-asetukset
-                                                                  :label (tr [:common-texts :navigation-email-notification-settings])
-                                                                  :href  "#/email-settings"}
-                                                                 {:key   :Käyttäjätilin-muokkaus
-                                                                  :label (tr [:common-texts :user-menu-profile])
-                                                                  :href "#/user"}
-                                                                 {:key   :Kirjaudu-ulos
-                                                                  :label (tr [:common-texts :user-menu-log-out])}]
-                                           :label               (get-in app [:user :name])
-                                           :prefix-icon         feather-icons/user
-                                           :state-flag          [:ote-service-flags :user-menu-open]
-                                           :menu-click-handler  #(e! (fp-controller/->ToggleUserMenu))
-                                           :entry-click-handler (fn [e entry]
-                                                                  (when (= (:key entry) :Kirjaudu-ulos)
-                                                                    (.preventDefault e)
-                                                                    (e! (fp-controller/->ToggleUserMenu))
-                                                                    (e! (login/->Logout))))}])
-    ; reagent version in this project is so old that it doesn't support fragments ([:<>]) so have to do these three
-    ; like so...
-    (when (and (not (user-logged-in? app))
-               (flags/enabled? :ote-login))
-      [bottombar-simplelink e! app {:label              (tr [:common-texts :navigation-login])
-                                    :menu-click-handler #(e! (login/->ShowLoginPage))}])
-
-    (when (not (user-logged-in? app)) [bottombar-spacer])
-
-    (when (not (user-logged-in? app))
-      [bottombar-simplelink e! app {:label              (tr [:common-texts :navigation-register])
-                                    :menu-click-handler #(e! (fp-controller/->ToggleRegistrationDialog))}])
-
-    [bottombar-spacer]
-
-    [bottombar-dropdown e! app desktop? {:tag                 :language-selector
-                                         :entries             [{:key "fi"
-                                                                :label "Suomeksi"}
-                                                               {:key "sv"
-                                                                :label "På Svenska"}
-                                                               {:key "en"
-                                                                :label "In English"}]
-                                         :label               (get-lang-label @localization/selected-language)
-                                         :prefix-icon         feather-icons/globe
-                                         :state-flag          [:ote-service-flags :lang-menu-open]
-                                         :menu-click-handler  #(e! (fp-controller/->ToggleLangMenu))
-                                         :entry-click-handler (fn [e entry]
-                                                                (.preventDefault e)
-                                                                (e! (fp-controller/->ToggleLangMenu))
-                                                                (e! (fp-controller/->SetLanguage (:key entry))))}]]])
+                                                                  (.preventDefault e)
+                                                                  (e! (fp-controller/->ToggleLangMenu))
+                                                                  (e! (fp-controller/->SetLanguage (:key entry))))}]]]))
 
 (def quicklink-urls
   {:fintraffic        {:url "https://www.fintraffic.fi/fi"                :langs {:fi "/fi" :sv "/sv" :en "/en"}}
@@ -348,7 +373,7 @@
       [:button (merge (stylefy/use-style (merge style-topnav/mobile-only
                                                 style-topnav/fintraffic-mobile-nav-button))
                       {:on-click #(e! (fp-controller/->ToggleFintrafficMenu))})
-       [:span {:style {:font-weight 600 :align-self "center"}} "Palvelut"]
+       [:span {:style {:font-weight 600 :align-self "center"}} "Palvelut"]  ; TODO: translations
        [(if menu-open?
          feather-icons/chevron-up
          feather-icons/chevron-down)
@@ -359,6 +384,6 @@
   [:header {:style {:box-shadow "0 2px 10px 0 rgba(0,0,0,0.1)"
                     :z-index    "100"}}
    [fintraffic-navbar e! app desktop?]
-   [nap-bottombar e! app]
+   [nap-bottombar e! app desktop?]
    [esc-press-listener e! app]
    [tos-notification e! app desktop?]])


### PR DESCRIPTION
# Added
* collapsible two-level menu for mobile layout

---

Screenshot in three parts:
 1. What it was like before (logged in)
 2. What it is now when collapsed (logged out)
 3. What it is now when expanded fully (logged out)

![image](https://user-images.githubusercontent.com/1393900/143557526-9779fee9-6fdc-4254-8e29-9025c00297cd.png)
