### PR TITLE
Use primary button type for CSV data download button in Monitor view.

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -393,6 +393,8 @@ You can also draw the operating area or point to the map with drawing tools. You
   :register-to-service "Register"
   :check-out-the-service "Explore the information"
   :continue-editing "Continue modifying the information"
+
+  :load-transport-service-operator-data-as-csv "TODO: translate into English: Lataa liikkumispalveluiden tarjoajien tiedot CSV:nä"
   }
 
  ;; Database enumeration values

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -391,6 +391,8 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :register-to-service "Rekisteröidy palveluun"
   :check-out-the-service "Tutustu tietoihin"
   :continue-editing "Jatka tietojen muokkaamista"
+
+  :load-transport-service-operator-data-as-csv "Lataa liikkumispalveluiden tarjoajien tiedot CSV:nä"
   }
 
  ;; Database enumeration values

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -396,6 +396,8 @@
   :register-to-service "Registrering"
   :check-out-the-service "Bekanta dig med informationen"
   :continue-editing "Fortsätt redigera uppgifter"
+
+  :load-transport-service-operator-data-as-csv "TODO: translate into Swedish: Lataa liikkumispalveluiden tarjoajien tiedot CSV:nä"
   }
 
  ;; Database enumeration values

--- a/ote/src/cljs/ote/views/admin/monitor.cljs
+++ b/ote/src/cljs/ote/views/admin/monitor.cljs
@@ -12,7 +12,8 @@
             [ote.style.base :as style-base]
             [cljs-react-material-ui.icons :as ic]
             [ote.time :as time]
-            [ote.ui.circular_progress :as circular-progress]))
+            [ote.ui.circular_progress :as circular-progress]
+            [re-svg-icons.feather-icons :as feather-icons]))
 
 ;; Patterned after the advice at
 ;; https://github.com/Day8/re-frame/blob/master/docs/Using-Stateful-JS-Components.md
@@ -116,15 +117,11 @@
 
      [:div {:style {:padding-top "2rem"}}
       [:div
-       [btn/big-icon-button-with-label
-        {:id "btn-all-companies-csv"
-         :on-click #(e! (monitor-controller/->DownloadCsv "/admin/reports/monitor/csv/all-companies" (str "yritykset-" (time/format-date-iso-8601 (time/now)) ".csv")))
-         :style {:padding "1rem"}}
-        [ic/action-description {:style {:width 30
-                                          :height 30
-                                          :margin-right "0.5rem"
-                                          :color colors/primary}}]
-        "Lataa liikkumispalveluiden tarjoajien tiedot CSV:nä"]]
+       (merge {:on-click #(e! (monitor-controller/->DownloadCsv "/admin/reports/monitor/csv/all-companies" (str "yritykset-" (time/format-date-iso-8601 (time/now)) ".csv")))
+               :id "btn-all-companies-csv"}
+              (stylefy/use-style style-buttons/primary-button))
+       [feather-icons/file-text {:style {:padding-right ".5rem"}}]
+       (tr [:buttons :load-transport-service-operator-data-as-csv])]
       [:div
        [form-fields/field
         {:label "Kaavioiden aikayksikkö"

--- a/ote/src/cljs/ote/views/own_services.cljs
+++ b/ote/src/cljs/ote/views/own_services.cljs
@@ -471,7 +471,7 @@
                :on-click #(do
                             (.preventDefault %)
                             (e! (to-controller/->CreateTransportOperator)))}
-              (stylefy/use-style style-buttons/outline-button))
+              (stylefy/use-style style-buttons/primary-button))
     (tr [:buttons :add-new-transport-operator])]])
 
 (defn- no-operator


### PR DESCRIPTION
# Added
* Add Finnish text "Lataa liikkumispalveluiden tarjoajien tiedot CSV:nä" to translations.
* As Swedish and English translations for this button text are missing, they have the Finnish text preceded by a TODO message to translate them into the corresponding target language.
   
# Changed
* Use primary button type for CSV data download button in Monitor view.