### PR TITLE
Use button text in Finnish as is in Swedish and English translations.

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -394,7 +394,7 @@ You can also draw the operating area or point to the map with drawing tools. You
   :check-out-the-service "Explore the information"
   :continue-editing "Continue modifying the information"
 
-  :load-transport-service-operator-data-as-csv "TODO: translate into English: Lataa liikkumispalveluiden tarjoajien tiedot CSV:nä"
+  :load-transport-service-operator-data-as-csv "Lataa liikkumispalveluiden tarjoajien tiedot CSV:nä"
   }
 
  ;; Database enumeration values

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -397,7 +397,7 @@
   :check-out-the-service "Bekanta dig med informationen"
   :continue-editing "Fortsätt redigera uppgifter"
 
-  :load-transport-service-operator-data-as-csv "TODO: translate into Swedish: Lataa liikkumispalveluiden tarjoajien tiedot CSV:nä"
+  :load-transport-service-operator-data-as-csv "Lataa liikkumispalveluiden tarjoajien tiedot CSV:nä"
   }
 
  ;; Database enumeration values


### PR DESCRIPTION
# Changed
* Use button text "Lataa liikkumispalveluiden tarjoajien tiedot CSV:nä" in Monitor view in Swedish and English as well.