### PR TITLE
FINAP-14/more buttons and icons

### DIFF
--- a/ote/src/cljs/ote/views/own_services.cljs
+++ b/ote/src/cljs/ote/views/own_services.cljs
@@ -42,7 +42,7 @@
                :on-click #(do
                             (.preventDefault %)
                             (e! (ts-controller/->DeleteTransportService id)))})
-    [feather-icons/trash-2]
+    [feather-icons/trash-2 (stylefy/use-style style-base/gray-link-with-icon)]
     [:span {:style {:padding-top "4px"}} (tr [:buttons :delete])]]
    (when show-delete-modal?
      [ui/dialog
@@ -155,7 +155,7 @@
                           :on-click #(do
                                        (.preventDefault %)
                                        (e! (fp-controller/->ChangePage :edit-service {:id id})))})
-               [feather-icons/edit]
+               [feather-icons/edit (stylefy/use-style style-base/gray-link-with-icon)]
                [:span {:style {:padding-top "4px"}} (tr [:buttons :edit])]]
               [delete-service-action e! row]]]]))
        (filter #(false? (::t-service/has-child? %)) services)))])

--- a/ote/src/cljs/ote/views/own_services.cljs
+++ b/ote/src/cljs/ote/views/own_services.cljs
@@ -154,12 +154,8 @@
                           :id (str "edit-service-button" id)
                           :on-click #(do
                                        (.preventDefault %)
-                                       (e! (fp-controller/->ChangePage :edit-service {:id id})))}
-                         (stylefy/use-style style-base/gray-link-with-icon))
-               (ic/content-create {:style {:width 24
-                                           :height 24
-                                           :margin-right "2px"
-                                           :color colors/icon-gray}})
+                                       (e! (fp-controller/->ChangePage :edit-service {:id id})))})
+               [feather-icons/edit]
                [:span {:style {:padding-top "4px"}} (tr [:buttons :edit])]]
               [delete-service-action e! row]]]]))
        (filter #(false? (::t-service/has-child? %)) services)))])

--- a/ote/src/cljs/ote/views/own_services.cljs
+++ b/ote/src/cljs/ote/views/own_services.cljs
@@ -27,7 +27,8 @@
             [ote.app.controller.transport-service :as ts-controller]
             [ote.views.transport-service.transport-service :as transport-service]
             [ote.views.transport-service.service-type :as service-type]
-            [ote.ui.common :as common]))
+            [ote.ui.common :as common]
+            [re-svg-icons.feather-icons :as feather-icons]))
 
 (def ic-warning [ic/alert-warning {:style {:color colors/negative-button
                                            :margin-bottom "5px"}}])
@@ -40,12 +41,8 @@
                :id (str "delete-service-button" id)
                :on-click #(do
                             (.preventDefault %)
-                            (e! (ts-controller/->DeleteTransportService id)))}
-              (stylefy/use-style style-base/gray-link-with-icon))
-    (ic/action-delete {:style {:width 24
-                               :height 24
-                               :margin-right "2px"
-                               :color colors/icon-gray}})
+                            (e! (ts-controller/->DeleteTransportService id)))})
+    [feather-icons/trash-2]
     [:span {:style {:padding-top "4px"}} (tr [:buttons :delete])]]
    (when show-delete-modal?
      [ui/dialog

--- a/ote/src/cljs/ote/views/pre_notices/listing.cljs
+++ b/ote/src/cljs/ote/views/pre_notices/listing.cljs
@@ -55,7 +55,7 @@
                                                 (.preventDefault %)
                                                 (e! (fp/->ChangePage :edit-pre-notice {:id (::transit/id row)})))}
                    (case state
-                     :draft [ic/content-create]
+                     :draft [feather-icons/edit]
                      :sent [ic/action-visibility])]]
 
                  (when (= :draft state)
@@ -64,7 +64,7 @@
                                      :on-click #(do
                                                   (.preventDefault %)
                                                   (e! (pre-notice/->DeletePreNotice row)))}
-                     [ic/action-delete]]])])}]
+                     [feather-icons/trash-2]]])])}]
       notices]]))
 
 (defn pre-notices [e! {:keys [transport-operator pre-notices delete-pre-notice-dialog] :as app}]

--- a/ote/src/cljs/ote/views/service_search.cljs
+++ b/ote/src/cljs/ote/views/service_search.cljs
@@ -24,17 +24,15 @@
             [ote.ui.page :as page]
             [ote.app.utils :as utils]
             [ote.style.dialog :as style-dialog]
-            [ote.format :as format]))
+            [ote.format :as format]
+            [re-svg-icons.feather-icons :as feather-icons]))
 
 (defn- delete-service-action [e! id name show-delete-modal?]
-  [:div {:style {:color "#fff"}}
-   [ui/icon-button {:href "#"
-                    :style style/delete-button
-                    :on-click #(do
-                                 (.preventDefault %)
-                                 (e! (admin/->DeleteTransportService id)))}
-    [ic/action-delete {:class-name (:class (stylefy/use-style style/delete-icon))
-                       :style style/partly-visible-delete-icon}]]
+  [:div
+   (merge {:on-click #(do
+                        (.preventDefault %)
+                        (e! (admin/->DeleteTransportService id)))})
+   [feather-icons/trash-2 (stylefy/use-style style/delete-icon)]
    (when show-delete-modal?
      [ui/dialog
       {:open true


### PR DESCRIPTION
# Changed
* Use feather-icons/trash-2 for delete transport service button in Transport service catalog.
* Use feather-icons/trash-2 for delete transport service button in Own transport services.
* Use feather-icons/edit for edit transport service button in Own transport services.
* Use Feather icons for edit and delete buttons in Report changes in regular scheduled passenger transport view.
![Screenshot from 2021-12-01 16-52-47](https://user-images.githubusercontent.com/91196748/144256748-ee606d09-1d15-444c-8ae7-609d7d634c12.png)
![Screenshot from 2021-12-01 18-03-48](https://user-images.githubusercontent.com/91196748/144269811-46ec9e06-ec03-47b0-9fdf-f9293384f640.png)


