### PR TITLE
FINAP-22/common link interceptor component for all links

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1163,6 +1163,8 @@ You can also draw the operating area or point to the map with drawing tools. You
   :have-read-services "I have read "
   :and-agree-service-terms " of the NAP service and accept "
   :of-service " of the service."
+
+  :follow-external-link-confirm "(EN) Olet poistumassa NAP-palvelusta. Haluatko varmasti jatkaa?"
   }
 
 

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1168,6 +1168,8 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :have-read-services "Olen tutustunut NAP-palvelun "
   :and-agree-service-terms " ja hyväksyn palvelun "
   :of-service "."
+
+  :follow-external-link-confirm "Olet poistumassa NAP-palvelusta. Haluatko varmasti jatkaa?"
   }
 
 

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1163,6 +1163,8 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
   :have-read-services "Jag har läst "
   :and-agree-service-terms " för NAP-tjänsten och godkänner "
   :of-service " för tjänsten."
+
+  :follow-external-link-confirm "(SV) Olet poistumassa NAP-palvelusta. Haluatko varmasti jatkaa?"
   }
 
 

--- a/ote/src/cljs/ote/style/base.cljs
+++ b/ote/src/cljs/ote/style/base.cljs
@@ -54,8 +54,12 @@
 
 (def base-link {:color colors/primary
                 :text-decoration "none"
-                ::stylefy/mode {:hover {:text-decoration "underline"
-                                        :color colors/primary-dark}}})
+                ::stylefy/mode {:hover {:text-decoration "underline"}}})
+
+(def inline-icon {:height "16px"
+                  :position "relative"
+                  :top "2px"
+                  :align-self "center"})
 
 (def base-button
   {:padding-left "1.1em"
@@ -187,7 +191,7 @@
 (def link-icon-container {:float "left" :padding-right "10px"})
 (def link-icon {:color "#06c" :height 18 :width 18})
 
-(def link-color "#2D75B4")
+(def link-color colors/primary-text-color)
 
 (def filters-form
   {:border "solid 1px #0046ad"})

--- a/ote/src/cljs/ote/style/topnav.cljs
+++ b/ote/src/cljs/ote/style/topnav.cljs
@@ -53,12 +53,9 @@
 (def nap-menu {:height "100%"
                :width "100%"})
 
-(def topbar-entry-icon {:color "#fff"
-                        :width "16px"
-                        :height "16px"
-                        :align-self "center"})
+(def topbar-entry-icon (merge base/inline-icon {:color "#fff"}))
 
-(def bottombar-entry-icon (merge topbar-entry-icon {:color "#000"}))
+(def bottombar-entry-icon (merge base/inline-icon {:color "#000"}))
 
 (def bottombar-entry-button {:display "flex"
                        :justify-content "center"

--- a/ote/src/cljs/ote/ui/main_header.cljs
+++ b/ote/src/cljs/ote/ui/main_header.cljs
@@ -78,15 +78,12 @@
        (for [{:keys [key label href target] :or {href "#"}} (filter some? entries)]
          ^{:key (str "link_" (name tag) "_" (name key))}  ; TODO: slugify
          [:li (stylefy/use-style style-topnav/bottombar-dropdown-item)
-          [:a (merge (stylefy/use-style style-topnav/bottombar-dropdown-link)
-                     {:key (name key)
-                      :href href
-                      ; the rewrapping of entry values to map is done manually instead of using map destructuring's
-                      ; :as directive because the :as doesn't include default values from :or directive
-                      :on-click #(entry-click-handler % {:key key :label label :href href})}
-                     (when (some? target)
-                       {:target target}))
-           (str label)]]))]
+          [common/linkify
+           href
+           (str label)
+           {:key      (name key)
+            :style    style-topnav/bottombar-dropdown-link
+            :on-click #(entry-click-handler % {:key key :label label :href href})}]]))]
     ]))
 
 (defn bottombar-simplelink [e! app options]
@@ -293,19 +290,23 @@
          ^{:key (str "quicklink_" (name service))}
          [:li (stylefy/use-style (merge style-topnav/fintraffic-quick-links-item
                                         (when (= service :finap) style-topnav/fintraffic-quick-links-active)))
-          [:a (merge (stylefy/use-style style-topnav/fintraffic-quick-links-link)
-                     {:href href})
-           (tr [:quicklink-header service])]
+          [common/linkify
+            href
+            (tr [:quicklink-header service])
+            {:style               style-topnav/fintraffic-quick-links-link
+             :hide-external-icon? true}]
           (when (= service :finap)
             [:div (stylefy/use-style style-topnav/fintraffic-quick-links-uparrow) ""])]))])
 
 (defn- fintraffic-navbar [e! app desktop?]
   (let [menu-open? (get-in app [:ote-service-flags :fintraffic-menu-open])]
     [:div (stylefy/use-style style-topnav/header-topbar)
-     [:a (merge (stylefy/use-style style-topnav/fintraffic-logo-link)
-                {:href (common/localized-quicklink-uri :fintraffic)})
+     [common/linkify
+      (common/localized-quicklink-uri :fintraffic)
       [:img {:style style-topnav/fintraffic-logo
-             :src "img/icons/Fintraffic_vaakalogo_valkoinen.svg"}]]
+             :src   "img/icons/Fintraffic_vaakalogo_valkoinen.svg"}]
+      {:style               style-topnav/fintraffic-logo-link
+       :hide-external-icon? true}]
      [:nav (stylefy/use-style style-topnav/fintraffic-quick-links)
       [:button (merge (stylefy/use-style (merge style-topnav/mobile-only
                                                 style-topnav/fintraffic-mobile-nav-button))

--- a/ote/src/cljs/ote/views/footer.cljs
+++ b/ote/src/cljs/ote/views/footer.cljs
@@ -2,7 +2,7 @@
   "NAP - footer"
   (:require [ote.localization :refer [tr tr-key] :as localization]
             [ote.style.footer :as footer-styles]
-            [ote.ui.common :as common :refer [linkify]]
+            [ote.ui.common :as common]
             [re-svg-icons.feather-icons :as feather-icons]
             [stylefy.core :as stylefy]))
 
@@ -26,7 +26,7 @@
    [:div (stylefy/use-style footer-styles/topbar)
     [:img (merge (stylefy/use-style footer-styles/fintraffic-logo)
                  {:src "img/icons/Fintraffic_vaakalogo_valkoinen.svg"})]
-    [:a (merge (stylefy/use-style footer-styles/link) {:href "https://fintraffic.fi"}) "fintraffic.fi"]]
+    [common/linkify "https://www.fintraffic.fi" "fintraffic.fi" {:style footer-styles/link :hide-external-icon? true}]]
 
    ; Fintraffic links
    [:div (stylefy/use-style footer-styles/site-links)
@@ -43,19 +43,24 @@
                                  :finap])]
           ^{:key (str "quicklink_" (name service))}
           [:li (stylefy/use-style footer-styles/site-link-entry)
-           [:a (stylefy/use-style footer-styles/link {:href href}) (tr [:quicklink-header service])]]))]]
+           [common/linkify href (tr [:quicklink-header service]) {:style footer-styles/link :hide-external-icon? true}]]))]]
 
     [:ul (stylefy/use-style footer-styles/fintraffic-legal-links)
      (let [language (or (keyword @localization/selected-language) :fi)]
        (doall
          (for [{:keys [href label]} (get legal-links language)]
            ^{:key (str "legallink_" (clojure.string/lower-case (name label)))}
-           [:li [:a (merge (stylefy/use-style footer-styles/link) {:href href})
-                 label]])))
+           [:li
+            [common/linkify
+             href
+             label
+             {:style               footer-styles/link
+              :hide-external-icon? true}]])))
      ]
 
     [:ul (stylefy/use-style footer-styles/fintraffic-support-link)
      [:li
+      ; linkify not used here as this is a mailto: link with very specific custom styling
       [:a (merge (stylefy/use-style footer-styles/link)
                  {:href (tr [:common-texts :navigation-feedback-link])})
        [:span {:style {:font-weight 600}} (tr [:common-texts :navigation-give-feedback])][:br]
@@ -63,18 +68,14 @@
 
    ; social media links
    [:div (stylefy/use-style footer-styles/some-link-wrapper)
-    [:a  (merge (stylefy/use-style footer-styles/some-link)
-                {:href "https://www.facebook.com/FintrafficFI"})
-     [feather-icons/facebook (stylefy/use-style footer-styles/some-link-icon)]]
-    [:a (merge (stylefy/use-style footer-styles/some-link)
-               {:href "https://twitter.com/Fintraffic_fi"})
-     [feather-icons/twitter (stylefy/use-style footer-styles/some-link-icon)]]
-    [:a (merge (stylefy/use-style footer-styles/some-link)
-               {:href "https://www.instagram.com/fintraffic_stories_fi"})
-     [feather-icons/instagram (stylefy/use-style footer-styles/some-link-icon)]]
-    [:a (merge (stylefy/use-style footer-styles/some-link)
-               {:href "https://www.youtube.com/channel/UCpnhwBRjt58yUu_Oky7vyxQ"})
-     [feather-icons/youtube (stylefy/use-style footer-styles/some-link-icon)]]
-    [:a (merge (stylefy/use-style footer-styles/some-link)
-               {:href "https://www.linkedin.com/company/fintraffic"})
-     [feather-icons/linkedin (stylefy/use-style footer-styles/some-link-icon)]]]])
+    (doall
+      (for [[link icon] [["https://www.facebook.com/FintrafficFI" feather-icons/facebook]
+                         ["https://twitter.com/Fintraffic_fi" feather-icons/twitter]
+                         ["https://www.instagram.com/fintraffic_stories_fi" feather-icons/instagram]
+                         ["https://www.youtube.com/channel/UCpnhwBRjt58yUu_Oky7vyxQ" feather-icons/youtube]
+                         ["https://www.linkedin.com/company/fintraffic" feather-icons/linkedin]]]
+        [common/linkify
+         link
+         [icon (stylefy/use-style footer-styles/some-link-icon)]
+         {:style               footer-styles/some-link
+          :hide-external-icon? true}]))]])

--- a/ote/src/cljs/ote/views/service_viewer.cljs
+++ b/ote/src/cljs/ote/views/service_viewer.cljs
@@ -6,6 +6,7 @@
             [clojure.spec.alpha :as s]
             [ote.ui.leaflet :as leaflet]
             [reagent.core :as r]
+            [re-svg-icons.feather-icons :as feather-icons]
             [ote.db.transport-operator :as t-operator]
             [ote.db.transport-service :as t-service]
             [ote.db.netex :as netex]
@@ -15,14 +16,12 @@
             [ote.ui.common :as common-ui]
             [ote.style.base :as style-base]
             [ote.localization :refer [tr supported-languages tr-key selected-language tr-tree]]
-            [ote.ui.icons :as icons]
             [ote.theme.colors :as colors]
             [ote.ui.link-icon :refer [link-with-icon]]
             [ote.style.service-viewer :as service-viewer]
             [ote.app.controller.place-search :as place-search]
             [ote.ui.form-fields :as form-fields]
-            [ote.style.base :as base]
-            [clojure.string :as str]))
+            [ote.style.base :as base]))
 
 (defonce shown-language
          (r/atom (string/upper-case (name @selected-language))))
@@ -140,11 +139,11 @@
 (defn- service-header
   [service-name o-id s-id]
   [:section
-   [common-ui/linkify "/#/services" [:span [icons/arrow-back {:position "relative"
-                                                              :top "6px"
-                                                              :padding-right "5px"
-                                                              :color style-base/link-color}]
-                                     (tr [:service-search :back-link])]]
+   [common-ui/linkify
+    "/#/services"
+    [:span
+     [feather-icons/arrow-left style-base/inline-icon]
+     (tr [:service-search :back-link])]]
    [:h1 {:style {:margin-top "1rem"}} service-name]
    [link-with-icon {:target-blank? true} open-in-new-icon (str "/export/geojson/" o-id "/" s-id) (tr [:service-viewer :open-in-geojson])]])
 


### PR DESCRIPTION
# Changed
* even more generalized `linkify` component which detects external links, renders an _(optional)_ external link icon next to the link and adds an on-click nagger if the URL is not a known good URL

---

![Screenshot 2021-12-07 at 15 43 31](https://user-images.githubusercontent.com/1393900/145040614-985f3005-f50c-4a02-b1e4-72977464d174.png)
![Screenshot 2021-12-07 at 15 43 49](https://user-images.githubusercontent.com/1393900/145040619-29b1cead-0741-426c-828b-c6421088a258.png)

# TODO

 - [ ] translations, as always

