### PR TITLE
FINAP-32/implement Ring middleware for throttling failed login attemps

### DIFF
--- a/ote/src/clj/ote/middleware/throttler.clj
+++ b/ote/src/clj/ote/middleware/throttler.clj
@@ -1,0 +1,63 @@
+(ns ote.components.middleware.throttler
+  (:import (java.time Instant)))
+
+(defn- hit!
+  "Tracks hits in session based on timestamps and expiration."
+  [session {root-key :session-key threshold-ms :threshold}]
+  (update-in
+    session
+    [root-key :hits]
+    (fn [old]
+      (let [now (-> (Instant/now) (.toEpochMilli))]
+        (conj
+          (vec (drop-while #(> (- now threshold-ms) %) (or old [])))
+          now)))))
+
+(defn- block
+  "Returns a future which will block exponentially based on hits in current session following formula `(2^hits) - 2`:
+
+   - 1 hit  => 0 seconds
+   - 2 hits => 2 seconds
+   - 3 hits => 6 seconds
+   - 4 hits => 14 seconds
+
+  and so on."
+  [session config]
+  (future
+    (let [delay (- (Math/pow 2 (count (get-in session [(:session-key config) :hits]))) 2)]
+      (Thread/sleep (* delay 1000)))))
+
+(defn- throttle*
+  [session response config]
+  (if (nil? (get #{200} (:status response)))
+    ; failure adds throttling metadata and delays response
+    (let [throttled-session (hit! session config)]
+      @(block throttled-session config)
+      (assoc response :session throttled-session))
+    ; success clears throttling metadata
+    (let [cleared-session (assoc-in session [(:session-key config) :hits] [])]
+      (assoc response :session cleared-session))))
+
+(defn throttle
+  ([handler]
+   (throttle handler {}))
+  ([handler opts]
+   (let [{:keys   [session-key             threshold]
+          :or     {session-key  :throttler threshold   60000}} opts
+         config   {:session-key session-key
+                   :threshold   threshold}]
+     (fn
+       ([request]
+        (throttle*
+          (:session request)
+          (handler request)
+          config))
+       ([request respond raise]
+        (handler
+          request
+          (fn [response]
+            (respond
+              (throttle*
+                (:session request)
+                response
+                config)))))))))

--- a/ote/src/clj/ote/middleware/throttler.clj
+++ b/ote/src/clj/ote/middleware/throttler.clj
@@ -24,8 +24,9 @@
   and so on."
   [session config]
   (future
-    (let [delay (- (Math/pow 2 (count (get-in session [(:session-key config) :hits]))) 2)]
-      (Thread/sleep (* delay 1000)))))
+    (let [hits  (count (get-in session [(:session-key config) :hits]))
+          delay (* 1000 (- (Math/pow 2 hits) 2))]
+      (Thread/sleep delay))))
 
 (defn- throttle*
   [session response config]

--- a/ote/src/clj/ote/middleware/throttler.clj
+++ b/ote/src/clj/ote/middleware/throttler.clj
@@ -1,4 +1,4 @@
-(ns ote.components.middleware.throttler
+(ns ote.middleware.throttler
   (:import (java.time Instant)))
 
 (defn- hit!

--- a/ote/src/clj/ote/services/login.clj
+++ b/ote/src/clj/ote/services/login.clj
@@ -3,7 +3,8 @@
   (:require [buddy.hashers :as hashers]
             [hiccup.core :refer [html]]
             [ote.components.http :as http]
-            [compojure.core :refer [routes POST]]
+            [ote.middleware.throttler :as throttler]
+            [compojure.core :refer [routes POST wrap-routes]]
             [ote.nap.cookie :as cookie]
             [ote.nap.users :as users]
             [jeesql.core :refer [defqueries]]
@@ -135,9 +136,10 @@
    :dependencies {email :email}}
 
   ^:unauthenticated
-  (POST "/login" {form-data :body}
-    (#'login db auth-tkt-config
-      (http/transit-request form-data)))
+  (-> (POST "/login" {form-data :body}
+        (#'login db auth-tkt-config
+          (http/transit-request form-data)))
+      (wrap-routes throttler/throttle))
 
   ^:unauthenticated
   (POST "/logout" []


### PR DESCRIPTION
# Added
* throttle failed login attempts using (almost) exponential delay, limited to a maximum wait of one minute

---

Inspector screenshot shows the behavior of this piece of code the best:
![throttle_patterns](https://user-images.githubusercontent.com/1393900/145395939-41490c57-5e34-45d3-96bb-df43903263fe.png)

