### PR TITLE
FINAP-64/add simple warning header to the page to differentiate test environments from production

### DIFF
--- a/ote/src/cljs/taxiui/views/components/devtools.cljs
+++ b/ote/src/cljs/taxiui/views/components/devtools.cljs
@@ -1,10 +1,29 @@
 (ns taxiui.views.components.devtools
   "Development mode tools and other niceties."
   (:require [reagent.core :as r]
-            [datafrisk.core :as df]))
+            [datafrisk.core :as df]
+            [clojure.string :as str]
+            [ote.theme.colors :as colors]
+            [stylefy.core :as stylefy]))
+
+(defonce test-env? (let [host (.-host (.-location js/document))]
+                     (or (str/includes? host "test")
+                         (str/includes? host "localhost"))))
 
 (defonce debug-visible? (r/atom (not= -1 (.indexOf js/document.location.host "localhost"))))
 
 (defn debug-state [app]
   (when @debug-visible?
      [df/DataFriskShell app]))
+
+(defn env-warning []
+  (when test-env?
+    [:div
+     [:h5 (stylefy/use-style {:color      colors/basic-black
+                              :background (str "repeating-linear-gradient(135deg,"
+                                               colors/dark-yellow  ","
+                                               colors/dark-yellow  " 20px,"
+                                               colors/basic-yellow " 20px,"
+                                               colors/basic-yellow " 40px)")
+                              :text-align "center"})
+      "Tämä on testipalvelu!"]]))

--- a/ote/src/cljs/taxiui/views/main.cljs
+++ b/ote/src/cljs/taxiui/views/main.cljs
@@ -16,6 +16,7 @@
   (fn [e! app]
     [:div (stylefy/use-style styles/main-flex-container)
      [header app]
+     [devtools/env-warning]
      ; TODO: add test env warning for Taxi UI hereabouts
      ; TODO: add cookie banner to this index
      (case (:page app)


### PR DESCRIPTION
Visible in localhost and test.

![Screenshot 2022-01-04 at 13 06 40](https://user-images.githubusercontent.com/1393900/148050150-aca73db4-ce9f-4043-b9b2-cf527a36a9c6.png)
