### PR TITLE
FINAP-61/bind statistics table to data returned by the backend

### DIFF
--- a/database/src/main/resources/db/migration/R__list_taxi_pricing_statistics.sql
+++ b/database/src/main/resources/db/migration/R__list_taxi_pricing_statistics.sql
@@ -1,0 +1,19 @@
+-- Function for listing taxi service pricing statistics. Function wrapping is used to avoid massive, repeating
+-- ORDER BY clause; the quote_ident etc. keeps sure this function is safe from SQLi.
+--
+-- Original from https://stackoverflow.com/a/8146245/44523, modified to our needs
+CREATE OR REPLACE FUNCTION list_taxi_pricing_statistics(ordering_column TEXT, ordering_direction BOOLEAN)
+    RETURNS SETOF taxi_service_prices AS
+$func$
+BEGIN
+    RETURN QUERY EXECUTE '
+         SELECT *
+           FROM (SELECT DISTINCT ON (service_id) *
+                   FROM taxi_service_prices
+                  ORDER BY service_id,
+                           timestamp DESC) AS s
+          ORDER BY s.' || QUOTE_IDENT(ordering_column) || ' ' ||
+                         (CASE WHEN ordering_direction = TRUE THEN 'ASC' ELSE 'DESC' END);
+END
+$func$
+LANGUAGE plpgsql;

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1751,10 +1751,10 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
   :finap "NAP"}
 
  ;; Taxi UI translations
- :taxi-ui {:stats {:name               "Yritys"
-                   :example-trip       "Esimerkkimatka"
-                   :cost-start-daytime "Aloitus (06-18)"
-                   :cost-travel-km     "Matka (per km)"
-                   :cost-travel-min    "Matka (per min)"
-                   :operation-area     "Toiminta-alue (ensisijainen)"}}
+ :taxi-ui {:stats {:name                "Yritys"
+                   :example-trip        "Esimerkkimatka"
+                   :start-price-daytime "Aloitus (06-18)"
+                   :price-per-kilometer "Matka (per km)"
+                   :price-per-minute    "Matka (per min)"
+                   :operation-area      "Toiminta-alue (ensisijainen)"}}
  }

--- a/ote/src/clj/ote/services/taxiui_service.clj
+++ b/ote/src/clj/ote/services/taxiui_service.clj
@@ -40,6 +40,11 @@
             ; TODO
             (log/info "Update areas with " areas-of-operation)))))))
 
+(defn fetch-pricing-statistics
+  [db {:keys [column direction]}]
+  (vec (list-pricing-statistics db {:column    (csk/->snake_case_string (or column :start-price-daytime))
+                                    :direction (= direction :ascending)})))
+
 (defrecord TaxiUIService []
   component/Lifecycle
   (start [{db :db http :http :as this}]
@@ -57,7 +62,13 @@
                                                                          user                             :user
                                                                          form-data                        :body}
                          (http/transit-response
-                           (update-priceinfo-for-service db user operator-id service-id (http/transit-request form-data))))))))
+                           (update-priceinfo-for-service db user operator-id service-id (http/transit-request form-data))))
+
+                    ^:unauthenticated
+                    (POST "/taxiui/statistics" {form-data :body}
+                      (log/info "form data " form-data)
+                      (http/transit-response
+                        (fetch-pricing-statistics db (http/transit-request form-data))))))))
 
   (stop [{stop ::stop :as this}]
     (stop)

--- a/ote/src/clj/ote/services/taxiui_service.sql
+++ b/ote/src/clj/ote/services/taxiui_service.sql
@@ -24,3 +24,17 @@ SELECT id,
 
 -- name: fetch-services-with-prices
 SELECT DISTINCT service_id FROM taxi_service_prices;
+
+-- name: list-pricing-statistics
+SELECT o.id AS "operator-id",
+       s.id AS "service-id",
+       CONCAT(o.name, '/', s.name) AS name,
+       l.timestamp AS timestamp,
+       l.start_price_daytime AS "start-price-daytime",
+       l.start_price_nighttime AS "start-price-nighttime",
+       l.start_price_weekend AS "start-price-weekend",
+       l.price_per_minute AS "price-per-minute",
+       l.price_per_kilometer AS "price-per-kilometer"
+  FROM list_taxi_pricing_statistics(:column, :direction) l
+  JOIN "transport-service" s ON l.service_id = s.id
+  JOIN "transport-operator" o ON s."transport-operator-id" = o.id;

--- a/ote/src/cljs/taxiui/app/controller/stats.cljs
+++ b/ote/src/cljs/taxiui/app/controller/stats.cljs
@@ -1,34 +1,39 @@
 (ns taxiui.app.controller.stats
-  (:require [taxiui.app.controller.loader :as loader]
+  (:require [cljs-time.core :as time]
+            [cljs-time.coerce :as tc]
+            [clojure.set :as set]
+            [taxiui.app.controller.loader :as loader]
             [taxiui.app.routes :as routes]
-            [tuck.core :as tuck]))
+            [tuck.core :as tuck]
+            [ote.communication :as comm]))
 
-(def test-data [{:name "Lavishbay Oy"      :updated 4  :example-trip 38.40 :cost-start-daytime 6.90 :cost-travel-km 1.25 :cost-travel-min 1.10 :operation-area "002"}
-                {:name "atlas Oy"          :updated 7  :example-trip 46.40 :cost-start-daytime 6.90 :cost-travel-km 1.25 :cost-travel-min 1.10 :operation-area "003"}
-                {:name "Putkosen Kyyti Oy" :updated 14 :example-trip 46.40 :cost-start-daytime 6.90 :cost-travel-km 1.25 :cost-travel-min 1.20 :operation-area "003"}
-                {:name "Inter Oy"          :updated 8  :example-trip 47.40 :cost-start-daytime 3.90 :cost-travel-km 1.25 :cost-travel-min 0.95 :operation-area "003"}
-                {:name "sense Oy"          :updated 7  :example-trip 37.40 :cost-start-daytime 3.90 :cost-travel-km 1.25 :cost-travel-min 0.95 :operation-area "003"}
-                {:name "dock Oy"           :updated 4  :example-trip 37.90 :cost-start-daytime 3.90 :cost-travel-km 1.25 :cost-travel-min 1.20 :operation-area "003"}
-                {:name "Puresierra Oy"     :updated 9  :example-trip 36.90 :cost-start-daytime 3.90 :cost-travel-km 1.25 :cost-travel-min 1.15 :operation-area "003"}
-                {:name "Overustic Oy"      :updated 2  :example-trip 38.90 :cost-start-daytime 3.90 :cost-travel-km 1.25 :cost-travel-min 1.15 :operation-area "002"}
-                {:name "Tribecapsule Oy"   :updated 1  :example-trip 38.90 :cost-start-daytime 3.90 :cost-travel-km 1.25 :cost-travel-min 1.25 :operation-area "004"}
-                {:name "Peakgram Oy"       :updated 0  :example-trip 38.90 :cost-start-daytime 3.90 :cost-travel-km 1.45 :cost-travel-min 1.25 :operation-area "004"}
-                {:name "Yonderness Oy"     :updated 5  :example-trip 28.90 :cost-start-daytime 3.90 :cost-travel-km 1.45 :cost-travel-min 1.25 :operation-area "004"}
-                {:name "Isletware Oy"      :updated 4  :example-trip 28.90 :cost-start-daytime 4.90 :cost-travel-km 1.45 :cost-travel-min 1.25 :operation-area "004"}
-                {:name "Omnitramp Oy"      :updated 6  :example-trip 28.90 :cost-start-daytime 4.90 :cost-travel-km 1.45 :cost-travel-min 1.25 :operation-area "006"}
-                {:name "Outway Oy"         :updated 11 :example-trip 28.90 :cost-start-daytime 4.90 :cost-travel-km 1.40 :cost-travel-min 1.25 :operation-area "006"}
-                {:name "Wayeon Oy"         :updated 10 :example-trip 28.20 :cost-start-daytime 5.90 :cost-travel-km 1.40 :cost-travel-min 1.25 :operation-area "006"}
-                {:name "Oneventure Oy"     :updated 9  :example-trip 28.20 :cost-start-daytime 5.90 :cost-travel-km 1.40 :cost-travel-min 1.25 :operation-area "002"}
-                {:name "Gocompass Oy"      :updated 8  :example-trip 28.20 :cost-start-daytime 5.90 :cost-travel-km 1.50 :cost-travel-min 1.25 :operation-area "002"}
-                {:name "Peakdistance Oy"   :updated 7  :example-trip 18.20 :cost-start-daytime 5.90 :cost-travel-km 1.50 :cost-travel-min 1.15 :operation-area "002"}
-                {:name "Migratestripe Oy"  :updated 12 :example-trip 18.20 :cost-start-daytime 4.90 :cost-travel-km 1.50 :cost-travel-min 1.05 :operation-area "002"}
-                {:name "Flycase Oy"        :updated 13 :example-trip 18.20 :cost-start-daytime 4.90 :cost-travel-km 1.50 :cost-travel-min 1.05 :operation-area "001"}
-                {:name "Pioneerload Oy"    :updated 22 :example-trip 18.20 :cost-start-daytime 4.90 :cost-travel-km 1.70 :cost-travel-min 1.05 :operation-area "001"}])
+(defn- sanitize
+  [statistics]
+  (->> statistics
+       (map
+         #(-> % (set/rename-keys {:timestamp :updated})))
+       (map #(update % :updated (fn [ts] (time/in-months (time/interval (time/minus (tc/from-date ts) (time/months (rand-int 24))) (time/now))))))))
+
+(tuck/define-event LoadStatisticsResponse [response]
+  {}
+  (let [sanitized (sanitize response)]
+    (tuck/fx
+      (assoc-in app [:taxi-ui :stats :companies] sanitized)
+      (fn [e!]
+        (e! (loader/->RemoveHit :page-loading))))))
+
+(tuck/define-event LoadStatisticsFailed [response]
+  {}
+  (js/console.log (str "LoadStatisticsFailed :: " response))
+  app)
 
 (tuck/define-event LoadStatistics [params]
   {}
-  (assoc-in app [:taxi-ui :companies] (->> test-data (random-sample 0.5) shuffle)))
+  (comm/post! (str "taxiui/statistics")
+              params
+              {:on-success (tuck/send-async! ->LoadStatisticsResponse)
+              :on-failure (tuck/send-async! ->LoadStatisticsFailed)})
+  app)
 
 (defmethod routes/on-navigate-event :taxi-ui/stats [{params :params}]
-  [(loader/->RemoveHit :page-loading)
-   (->LoadStatistics params)])
+  [(->LoadStatistics params)])


### PR DESCRIPTION
All statistics keys are now harmonized between various components ranging from translations to database column names.

Known issues:
 - Table cannot sorted by service provider name, since that's actually a concatenation of two joined columns and outside the evaluation scope of actual `ORDER BY` clause.
 - Area code column is missing
 - Example price column is missing

All these are documented in JIRA.

![Screenshot 2022-01-13 at 15 43 25](https://user-images.githubusercontent.com/1393900/149342001-79fde5ca-4142-4f60-bcea-e9af9259c6c3.png)

