### PR TITLE
FINAP-60/operating area databinding

### DIFF
--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1756,5 +1756,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
                    :start-price-daytime "Aloitus (06-18)"
                    :price-per-kilometer "Matka (per km)"
                    :price-per-minute    "Matka (per min)"
-                   :operation-area      "Toiminta-alue (ensisijainen)"}}
+                   :operation-area      "Toiminta-alue (ensisijainen)"}
+           :loader {:page-loading              "Ladataan..."
+                    :loading-price-information "Ladataan hintatietoja..."}}
  }

--- a/ote/src/cljc/ote/transit.cljc
+++ b/ote/src/cljc/ote/transit.cljc
@@ -40,6 +40,8 @@
               ;; Transit "f" tag is an arbitrary precision decimal number that has no native
               ;; JS equivalent, for now we simply map it to parseFloat in JS as we are not doing
               ;; calculations with money
+              ;; XXX: January 14 2022 update: We are now handling calculations with money, but this cannot be changed
+              ;;      anymore since it would break a lot of the existing UI :)
               "f" #?(:clj (t/read-handler #(BigDecimal. %))
                      :cljs js/parseFloat)
               "geo" #?(:clj (t/read-handler identity)

--- a/ote/src/cljs/taxiui/styles/pricing_details.cljs
+++ b/ote/src/cljs/taxiui/styles/pricing_details.cljs
@@ -16,7 +16,8 @@
 
 (def spacer {:width "1em"})
 
-(def area-pills {:display "flex"})
+(def area-pills {:display "flex"
+                 :flex-wrap "wrap"})
 
 (def autocomplete-result {:white-space   "nowrap"
                           :overflow      "hidden"

--- a/ote/src/cljs/taxiui/views/components/loader.cljs
+++ b/ote/src/cljs/taxiui/views/components/loader.cljs
@@ -2,9 +2,10 @@
   "Dead simple full page spinner"
   (:require [re-svg-icons.feather-icons :as feather-icons]
             [stylefy.core :as stylefy]
+            [ote.localization :refer [tr tr-key]]
             [ote.theme.colors :as colors]))
 
-(def ^:private max-opacity "0.8")
+(def ^:private max-opacity "0.9")
 
 (stylefy/keyframes "simple-animation"
                    [:from
@@ -16,16 +17,21 @@
   [_ _]
   (fn
     [app path]
-    (let [show? (-> (get-in app path) keys some?)]
+    (let [show?  (-> (get-in app path) keys some?)]
       [:div (stylefy/use-style {:z-index          1985
                                 :height           "100vh"
                                 :width            "100vw"
                                 :position         "absolute"
                                 :background-color colors/basic-white
                                 :display          (if show? "flex" "none")
+                                :flex-direction   "column"
                                 :opacity          max-opacity
                                 :align-items      "center"
                                 :justify-content  "center"})
        [feather-icons/loader {:style   {:animation "simple-animation 3s infinite linear"}
                               :width   "16em"
-                              :height  "16em"}]])))
+                              :height  "16em"}]
+       (doall
+         (for [label (-> (get-in app path) keys)]
+           ^{:key (str "loading-" label)}
+           [:span (tr [:taxi-ui :loader label])]))])))

--- a/ote/src/cljs/taxiui/views/components/pill.cljs
+++ b/ote/src/cljs/taxiui/views/components/pill.cljs
@@ -23,8 +23,10 @@
   ([label {:keys [filled? clickable]
            :or   {filled? false clickable nil}}]
 
-   (let [root-styles  {:display     "flex"
-                       :align-items "center"}
+   (let [root-styles  {:display       "flex"
+                       :align-items   "center"
+                       :margin-top    "0.25em"
+                       :margin-bottom "0.25em"}
          pill         [:span (stylefy/use-style (if filled? area-pill-filled area-pill)) label]
          button       [feather-icons/x-circle {:stroke colors/accessible-red
                                                :style  pill-button}]]


### PR DESCRIPTION
# Added
* operating areas are now stored to database; existing ones are cleared if they have been removed, new ones will be saved as expected
* loader spinner now can have localized context specific helper texts below it, just to calm the users a bit
![Screenshot 2022-01-17 at 13 15 33](https://user-images.githubusercontent.com/1393900/149760597-f2ab2f11-5ff8-4206-a753-eb79ebc6725a.png)

