### PR TITLE
FINAP-61/add primary operating areas to statistic view results

### DIFF
--- a/database/src/main/resources/db/migration/R__list_taxi_pricing_statistics.sql
+++ b/database/src/main/resources/db/migration/R__list_taxi_pricing_statistics.sql
@@ -1,4 +1,7 @@
--- Function for listing taxi service pricing statistics. Function wrapping is used to avoid massive, repeating
+-- Functions for listing taxi service pricing statistics.
+-- list_taxi_statistics(...) is meant to be called directly, other functions are helpers
+
+-- Function wrapping is used to avoid a massive, repeating
 -- ORDER BY clause; the quote_ident etc. keeps sure this function is safe from SQLi.
 --
 -- Original from https://stackoverflow.com/a/8146245/44523, modified to our needs
@@ -12,8 +15,63 @@ BEGIN
                    FROM taxi_service_prices
                   ORDER BY service_id,
                            timestamp DESC) AS s
-          ORDER BY s.' || QUOTE_IDENT(ordering_column) || ' ' ||
-                         (CASE WHEN ordering_direction = TRUE THEN 'ASC' ELSE 'DESC' END);
+          ' || (CASE WHEN ordering_column IS NOT NULL AND ordering_direction IS NOT NULL
+                     THEN 'ORDER BY s.' || QUOTE_IDENT(ordering_column) || ' ' ||
+                          (CASE WHEN ordering_direction = TRUE
+                                THEN 'ASC'
+                                ELSE 'DESC'
+                           END)
+                     ELSE ''
+                END);
+END
+$func$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION list_taxi_statistics(
+    primary_ordering_column TEXT,
+    primary_ordering_direction BOOLEAN,
+    secondary_ordering_column TEXT,
+    secondary_ordering_direction BOOLEAN)
+    RETURNS TABLE (
+                      "operator-id" integer,
+                      "service-id" integer,
+                      "name" text,
+                      "timestamp" timestamp,
+                      "start-price-daytime" numeric,
+                      "start-price-nighttime" numeric,
+                      "start-price-weekend" numeric,
+                      "price-per-minute" numeric,
+                      "price-per-kilometer" numeric,
+                      "operating-areas" text[]
+                  ) AS
+$func$
+BEGIN
+    RETURN QUERY EXECUTE '
+        SELECT o.id AS "operator-id",
+               s.id AS "service-id",
+               CONCAT(o."name", ''/'', s."name") AS "name",
+               l.timestamp AS "timestamp",
+               l.start_price_daytime AS "start-price-daytime",
+               l.start_price_nighttime AS "start-price-nighttime",
+               l.start_price_weekend AS "start-price-weekend",
+               l.price_per_minute AS "price-per-minute",
+               l.price_per_kilometer AS "price-per-kilometer",
+               (SELECT array_agg(oa_d.text)
+                  FROM operation_area oa,
+                       unnest(description) AS oa_d
+                 WHERE oa."transport-service-id" = l."service_id"
+                   AND "primary?" = TRUE) AS "operating-areas"
+          FROM list_taxi_pricing_statistics(' || (CASE WHEN primary_ordering_column IS NULL THEN 'NULL' ELSE '''' || primary_ordering_column || '''' END) || ', ' || (CASE WHEN primary_ordering_direction IS NULL THEN 'NULL' ELSE '''' || primary_ordering_direction || '''' END) || ') l
+          JOIN "transport-service" s ON l."service_id" = s."id"
+          JOIN "transport-operator" o ON s."transport-operator-id" = o."id"
+         ' || (CASE WHEN secondary_ordering_column IS NOT NULL AND secondary_ordering_direction IS NOT NULL
+                    THEN ' ORDER BY ' || QUOTE_IDENT(secondary_ordering_column) || ' ' ||
+                         (CASE WHEN secondary_ordering_direction = TRUE
+                               THEN 'ASC'
+                               ELSE 'DESC'
+                          END)
+                    ELSE ''
+               END);
 END
 $func$
 LANGUAGE plpgsql;

--- a/database/src/main/resources/db/migration/R__list_taxi_pricing_statistics.sql
+++ b/database/src/main/resources/db/migration/R__list_taxi_pricing_statistics.sql
@@ -61,7 +61,17 @@ BEGIN
                        unnest(description) AS oa_d
                  WHERE oa."transport-service-id" = l."service_id"
                    AND "primary?" = TRUE) AS "operating-areas"
-          FROM list_taxi_pricing_statistics(' || (CASE WHEN primary_ordering_column IS NULL THEN 'NULL' ELSE '''' || primary_ordering_column || '''' END) || ', ' || (CASE WHEN primary_ordering_direction IS NULL THEN 'NULL' ELSE '''' || primary_ordering_direction || '''' END) || ') l
+          FROM list_taxi_pricing_statistics('
+                             || (CASE WHEN primary_ordering_column IS NULL
+                                      THEN 'NULL'
+                                      ELSE '''' || primary_ordering_column || ''''
+                                 END)
+                             || ', '
+                             || (CASE WHEN primary_ordering_direction IS NULL
+                                      THEN 'NULL'
+                                      ELSE '''' || primary_ordering_direction || ''''
+                                 END)
+                             || ') l
           JOIN "transport-service" s ON l."service_id" = s."id"
           JOIN "transport-operator" o ON s."transport-operator-id" = o."id"
          ' || (CASE WHEN secondary_ordering_column IS NOT NULL AND secondary_ordering_direction IS NOT NULL

--- a/ote/project.clj
+++ b/ote/project.clj
@@ -146,8 +146,7 @@
                  [alandipert/storage-atom "2.0.1"]
 
                  ; A Clojure[Script] library for word case conversions - Eclipse Public License 1.0
-                 [camel-snake-kebab "0.4.2"]
-                 ]
+                 [camel-snake-kebab "0.4.2"]]
   :profiles {:uberjar {:aot :all
 
                        ;; Prevent uberjar from cleaning cljs generated files

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1756,7 +1756,7 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
                    :start-price-daytime "Aloitus (06-18)"
                    :price-per-kilometer "Matka (per km)"
                    :price-per-minute    "Matka (per min)"
-                   :operation-area      "Toiminta-alue (ensisijainen)"}
+                   :operating-areas     "Toiminta-alue (ensisijainen)"}
            :loader {:page-loading              "Ladataan..."
                     :loading-price-information "Ladataan hintatietoja..."}}
  }

--- a/ote/src/clj/ote/services/taxiui_service.clj
+++ b/ote/src/clj/ote/services/taxiui_service.clj
@@ -83,7 +83,6 @@
 
 (defn fetch-pricing-statistics
   [db {:keys [column direction]}]
-  (log/info "fetch-pricing-statistics ::" column " " direction)
   (let [secondary-columns   #{:name :operating-areas}
         secondary-column    (get secondary-columns column)
         primary-column      (when-not secondary-column column)

--- a/ote/src/clj/ote/services/taxiui_service.sql
+++ b/ote/src/clj/ote/services/taxiui_service.sql
@@ -26,15 +26,4 @@ SELECT id,
 SELECT DISTINCT service_id FROM taxi_service_prices;
 
 -- name: list-pricing-statistics
-SELECT o.id AS "operator-id",
-       s.id AS "service-id",
-       CONCAT(o."name", '/', s."name") AS "name",
-       l.timestamp AS "timestamp",
-       l.start_price_daytime AS "start-price-daytime",
-       l.start_price_nighttime AS "start-price-nighttime",
-       l.start_price_weekend AS "start-price-weekend",
-       l.price_per_minute AS "price-per-minute",
-       l.price_per_kilometer AS "price-per-kilometer"
-  FROM list_taxi_pricing_statistics(:column, :direction) l
-  JOIN "transport-service" s ON l."service_id" = s."id"
-  JOIN "transport-operator" o ON s."transport-operator-id" = o."id";
+SELECT * FROM list_taxi_statistics(:primary-column, :primary-direction, :secondary-column, :secondary-direction);

--- a/ote/src/cljs/taxiui/views/components/formatters.cljs
+++ b/ote/src/cljs/taxiui/views/components/formatters.cljs
@@ -1,6 +1,7 @@
 (ns taxiui.views.components.formatters
   "Various single value decorator formatters, such as pretty formatting for currencies"
-  (:require [ote.theme.colors :as colors]))
+  (:require [ote.theme.colors :as colors]
+            [clojure.string :as str]))
 
 (defn currency
   "Formats given value as euros as per Finnish locale. Tries to normalize decimal delimiter."
@@ -24,3 +25,8 @@
                                       (< value high)   colors/basic-yellow
                                       :else            colors/basic-red)
                   }}])
+
+(defn joining
+  [delimiter renderer]
+  (fn [s]
+    (str/join delimiter (map renderer s))))

--- a/ote/src/cljs/taxiui/views/stats.cljs
+++ b/ote/src/cljs/taxiui/views/stats.cljs
@@ -28,13 +28,13 @@
 
 (defn- table
   [e! companies]
-  (let [state (r/atom {:columns [{:label :name                :sortable? false :renderer str}
-                                 {:label :updated             :sortable? false :renderer (partial formatters/street-light 0 6 12)}
-                                 #_{:label :example-trip      :sortable? true  :renderer formatters/currency}
-                                 {:label :start-price-daytime :sortable? true  :renderer formatters/currency}
-                                 {:label :price-per-kilometer :sortable? true  :renderer formatters/currency}
-                                 {:label :price-per-minute    :sortable? true  :renderer formatters/currency}
-                                 #_{:label :operation-area    :sortable? true  :renderer str}]
+  (let [state (r/atom {:columns [{:label :name                :sortable? true   :renderer str}
+                                 {:label :updated             :sortable? false  :renderer (partial formatters/street-light 0 6 12)}
+                                 #_{:label :example-trip      :sortable? true   :renderer formatters/currency}
+                                 {:label :start-price-daytime :sortable? true   :renderer formatters/currency}
+                                 {:label :price-per-kilometer :sortable? true   :renderer formatters/currency}
+                                 {:label :price-per-minute    :sortable? true   :renderer formatters/currency}
+                                 {:label :operating-areas     :sortable? true   :renderer (formatters/joining ", " str)}]
                        :sorting {:column    :start-price-daytime  ;; TODO: just a hardcoded test value
                                  :direction :ascending}})]  ; cycles between :ascending, :descending
     (fn [e! companies]


### PR DESCRIPTION
Adds primary operating areas to the table, and a two-level sorting to enable sort for both name and operating areas column.
![Screenshot 2022-01-17 at 16 40 26](https://user-images.githubusercontent.com/1393900/149790088-c7b13c7e-ef9d-4b92-b2a4-503046988fab.png)

