### PR TITLE
FINAP-61/fix date range comparison by comparing only the filter interval

### DIFF
--- a/ote/src/clj/ote/services/taxiui_service.sql
+++ b/ote/src/clj/ote/services/taxiui_service.sql
@@ -32,8 +32,7 @@ SELECT id,
 -- name: list-pricing-statistics
 SELECT *
   FROM list_taxi_statistics(:primary-column, :primary-direction, :secondary-column, :secondary-direction)
- WHERE (CASE
-            WHEN EXTRACT(YEAR FROM AGE(timestamp - (:age-filter)::INTERVAL)) >= 1
+ WHERE (CASE WHEN EXTRACT(YEAR FROM (:age-filter)::interval) > 0
                 THEN timestamp < NOW() - INTERVAL '1 year'
             ELSE timestamp > NOW() - (:age-filter)::INTERVAL
      END);


### PR DESCRIPTION
Previous logic, upon further inspection, didn't really make sense.