### PR TITLE
FINAP-61/Add params to function drop to disambiguate which function should be removed

### DIFF
--- a/database/src/main/resources/db/migration/R__list_taxi_pricing_statistics.sql
+++ b/database/src/main/resources/db/migration/R__list_taxi_pricing_statistics.sql
@@ -28,7 +28,7 @@ $func$
 LANGUAGE plpgsql;
 
 -- function needs to be dropped in case its return type changes, simple replace won't work in such case
-DROP FUNCTION IF EXISTS list_taxi_statistics;
+DROP FUNCTION IF EXISTS list_taxi_statistics(TEXT, BOOLEAN, TEXT, BOOLEAN);
 
 CREATE OR REPLACE FUNCTION list_taxi_statistics(
     primary_ordering_column TEXT,


### PR DESCRIPTION
Seems the function overloads turned ambiguous in test environment at least, so need to add params.