### PR TITLE
Finap 95/session timeout

### DIFF
--- a/ote/project.clj
+++ b/ote/project.clj
@@ -106,7 +106,7 @@
                  ;; Time - Eclipse Public License 1.0
                  [com.andrewmcveigh/cljs-time "0.5.0"]
                  ;; java-time - MIT
-                 [clojure.java-time "0.3.2"]
+                 [clojure.java-time "0.3.3"]
 
                  ;; HTML/XML generation from Clojure data - Eclipse Public License 1.0
                  [hiccup "1.0.5"]

--- a/ote/src/clj/ote/services/login.clj
+++ b/ote/src/clj/ote/services/login.clj
@@ -28,7 +28,7 @@
 
 (defqueries "ote/services/login.sql")
 
-(defn- unix-epoch []
+(defn ^:private unix-epoch []
   ;; Returns a zoned date-time that can later be
   ;; formatted as: "Thu, 1 Jan 1970 00:00:00 GMT"
   (java-time.zone/zoned-date-time 1970 "UTC"))

--- a/ote/src/clj/ote/services/login.clj
+++ b/ote/src/clj/ote/services/login.clj
@@ -66,13 +66,10 @@
                              :user-id          (:id login-info)
                              :user-data        {:session-start-timestamp current-zoned-timestamp}})
             (:domain auth-tkt-config)
-            ;; Timestamp for cookie expiration.
-            (let
-              ; Define the session duration here.
-              [session-duration-in-hours 8]                 ; Define the session duration here!
-              ;; If you want to use minutes or seconds instead of hours,
-              ;; change the line before and after this to match the unit in use.
-              (.plus current-zoned-timestamp (java-time.amount/hours session-duration-in-hours)))
+            ; Define the absolute session timeout in hours.
+            ; If you want to use minutes or seconds instead of hours,
+            ; change the line below to match the unit in use.
+            (.plus current-zoned-timestamp (java-time.amount/hours 8))
             false))
 
         (http/transit-response {:error :unconfirmed-email} 401)) ;; This could be 403 instead

--- a/ote/src/clj/ote/services/login.clj
+++ b/ote/src/clj/ote/services/login.clj
@@ -29,7 +29,7 @@
 (defqueries "ote/services/login.sql")
 
 (defn- unix-epoch []
-  ;; Returns a zoned time date that can later be
+  ;; Returns a zoned date-time that can later be
   ;; formatted as: "Thu, 1 Jan 1970 00:00:00 GMT"
   (java-time.zone/zoned-date-time 1970 "UTC"))
 

--- a/ote/src/clj/ote/services/login.clj
+++ b/ote/src/clj/ote/services/login.clj
@@ -28,13 +28,13 @@
 
 (defqueries "ote/services/login.sql")
 
-(defn ^:private unix-epoch []
+(def ^:private unix-epoch
   ;; Returns a zoned date-time that can later be
   ;; formatted as: "Thu, 1 Jan 1970 00:00:00 GMT"
   (java-time.zone/zoned-date-time 1970 "UTC"))
 
 (defn- with-auth-tkt [response auth-tkt-value domain expiry-timestamp is-deleted]
-  (let [timestamp-string (java-time.format/format :rfc-1123-date-time (if is-deleted (unix-epoch) expiry-timestamp))]
+  (let [timestamp-string (java-time.format/format :rfc-1123-date-time (if is-deleted unix-epoch expiry-timestamp))]
     (update response :headers
             assoc "Set-Cookie" (if (nil? domain)
                                  [(str "auth_tkt=" auth-tkt-value (if is-deleted "; token=" "") "; Path=/; HttpOnly; Expires=" timestamp-string)]
@@ -78,7 +78,7 @@
     (http/transit-response {:error :login-error} 400)))
 
 (defn- logout [auth-tkt-config]
-  (with-auth-tkt (http/transit-response :ok) "" (:domain auth-tkt-config) (unix-epoch) true))
+  (with-auth-tkt (http/transit-response :ok) "" (:domain auth-tkt-config) unix-epoch true))
 
 (defn- request-password-reset! [db {:keys [email]}]
   (tx/with-transaction db

--- a/ote/src/clj/ote/services/login.clj
+++ b/ote/src/clj/ote/services/login.clj
@@ -37,12 +37,12 @@
   (let [timestamp-string (java-time.format/format :rfc-1123-date-time (if is-deleted (unix-epoch) expiry-timestamp))]
     (update response :headers
             assoc "Set-Cookie" (if (nil? domain)
-                                 [(str "auth_tkt=" auth-tkt-value "; Path=/; HttpOnly; Expires=" timestamp-string)]
+                                 [(str "auth_tkt=" auth-tkt-value (if is-deleted "; token=" "") "; Path=/; HttpOnly; Expires=" timestamp-string)]
                                  ;; Three cookies are required to match ckan cookie configuration
-                                 [(str "auth_tkt=" auth-tkt-value "; Path=/; HttpOnly; Secure; Expires=" timestamp-string)
-                                  (str "auth_tkt=" auth-tkt-value "; Path=/; HttpOnly"
+                                 [(str "auth_tkt=" auth-tkt-value (if is-deleted "; token=" "") "; Path=/; HttpOnly; Secure; Expires=" timestamp-string)
+                                  (str "auth_tkt=" auth-tkt-value (if is-deleted "; token=" "") "; Path=/; HttpOnly"
                                        "; Domain=" domain "; Secure; Expires=" timestamp-string)
-                                  (str "auth_tkt=" auth-tkt-value "; Path=/; HttpOnly"
+                                  (str "auth_tkt=" auth-tkt-value (if is-deleted "; token=" "") "; Path=/; HttpOnly"
                                        "; Domain=." domain "; Secure; Expires=" timestamp-string)]))))
 
 (defn login [db auth-tkt-config


### PR DESCRIPTION
# Changed
* Set `Expires` timestamp string for `auth_tkt` cookie.
* Upon logout set `Expires` timestamp string to Unix epoch.
* Use "UTC" as the zone id. The timestamp string follows the RFC 1123.
    Example: "Thu, 1 Jan 1970 00:00:00 GMT"
* Update java-time package.

Does not work properly yet ("Ongelma palvelinkutsussa"):
![Screenshot from 2022-01-27 15-03-06](https://user-images.githubusercontent.com/91196748/151364298-00a53720-9b3d-497f-804a-d61a67958829.png)