### PR TITLE
Finap 105/change link of swedish and english privacy policies

### DIFF
--- a/ote/src/cljs/ote/views/footer.cljs
+++ b/ote/src/cljs/ote/views/footer.cljs
@@ -16,7 +16,7 @@
         {:href "https://www.fintraffic.fi/fi/yhteystiedot" :label "Yhteystiedot"}
         {:href "https://www.fintraffic.fi/fi/fintraffic/saavutettavuusseloste" :label "Saavutettavuus"}]
    :sv [{:href "https://www.fintraffic.fi/sv/fintraffic/kontaktuppgifter" :label "Kontaktinformation"}
-        {:href "https://www.fintraffic.fi/sv/fintraffic/dataskydd" :label "Dataskydd"}]
+        {:href "https://www.fintraffic.fi/fi/ekosysteemi-tietosuoja" :label "Dataskydd"}]
    :en [{:href "https://www.fintraffic.fi/en/fintraffic/contact-information-and-invoicing-instructions" :label "Contact information"}
         {:href "https://www.fintraffic.fi/en/fintraffic/privacy-policy" :label "Privacy policy"}]})
 

--- a/ote/src/cljs/ote/views/footer.cljs
+++ b/ote/src/cljs/ote/views/footer.cljs
@@ -18,7 +18,7 @@
    :sv [{:href "https://www.fintraffic.fi/sv/fintraffic/kontaktuppgifter" :label "Kontaktinformation"}
         {:href "https://www.fintraffic.fi/fi/ekosysteemi-tietosuoja" :label "Dataskydd"}]
    :en [{:href "https://www.fintraffic.fi/en/fintraffic/contact-information-and-invoicing-instructions" :label "Contact information"}
-        {:href "https://www.fintraffic.fi/en/fintraffic/privacy-policy" :label "Privacy policy"}]})
+        {:href "https://www.fintraffic.fi/fi/ekosysteemi-tietosuoja" :label "Privacy policy"}]})
 
 (defn footer []
   [:footer (stylefy/use-style footer-styles/footer)


### PR DESCRIPTION
# Changed
* Swedish "Dataskydd" link points now to Finnish "Tietosuojaseloste" page.
* English "Privacy policy" link points now to Finnish "Tietosuojaseloste" page.