### PR TITLE
FINAP-64/more layout finetuning

### DIFF
--- a/ote/src/cljs/taxiui/views/components/forms.cljs
+++ b/ote/src/cljs/taxiui/views/components/forms.cljs
@@ -121,7 +121,6 @@
                  :display          "none"}
          :id results-id}
     (let [results (get-in app (conj storage-path :results))]
-      (js/console.log (str "search results >> " results))
       (doall
         (for [[index result] (map-indexed vector results)
               :when (some? results)]
@@ -158,7 +157,10 @@
                       false)))
       :on-blur  (fn [e]
                   (when-not (.contains (.. e -currentTarget -parentElement) (.. e -relatedTarget))
-                    (set! (.. (.getElementById js/document results-id) -style -display) "none")))
+                    (set! (.. (.getElementById js/document results-id) -style -display) "none"))
+                  (when (str/blank? (.. e -target -value))
+                    (e! (->UserSelectedResult selected-fn (conj storage-path :selected) nil))
+                    (selected-fn nil)))
       :on-input (fn [e]
                   (search e! search-fn result-fn storage-path (.. e -target -value)))}
      [autocomplete-results e! app selected-fn autocomplete-input-id result-container-id results-id storage-path]]))

--- a/ote/src/cljs/taxiui/views/components/forms.cljs
+++ b/ote/src/cljs/taxiui/views/components/forms.cljs
@@ -35,12 +35,10 @@
                                           :background-color colors/basic-white})
                                   (theme/breather-padding)))
 
-(def ^:private input-wrapper {:padding-bottom "1.5em"})
-
 (defn- form-element
   "Creates an accessible form element container with fancy label and optional content."
   [el id label styles props inner-content post-content]
-  [:div (stylefy/use-style input-wrapper)
+  [:div
    [:h5
     (cond
       (nil? label) [:br]  ; this simulates empty header line, which aligns form elements when placed together

--- a/ote/src/cljs/taxiui/views/pricing_details.cljs
+++ b/ote/src/cljs/taxiui/views/pricing_details.cljs
@@ -15,6 +15,11 @@
             [ote.theme.colors :as colors]
             [reagent.core :as r]))
 
+(defn- input-spacer
+  "Purpose of this element is to push the inputs apart a bit to make the UI lighter."
+  []
+  [:div {:style {:padding-bottom "1.5em"}} " "])
+
 (defn- pricing-input
   [e! app tab-index id]
   [forms/input
@@ -34,7 +39,7 @@
           (when-let [existing-price (get-in app [:taxi-ui :pricing-details :price-information :prices id])]
             {:data-rawvalue existing-price
              :placeholder   (formatters/currency existing-price)}))
-   nil])
+   (input-spacer)])
 
 (defn- autocomplete-results
   [e! results]

--- a/ote/src/cljs/taxiui/views/stats.cljs
+++ b/ote/src/cljs/taxiui/views/stats.cljs
@@ -138,7 +138,7 @@
      [forms/autocomplete-input
       e!
       app
-      :testing
+      :area-filter
       [:taxi-ui :stats :area-selector]
       [:taxi-ui :stats :sections :filters]
       (fn [term] {:method :post :url "/taxiui/operating-areas" :params {:filter term}})


### PR DESCRIPTION
Lets keep pushing those pixels. No screenshots this time, things are just...better :)

 - when user clears area filter, it now equates to "all areas" search which is more intuitive
 - Stats page are selector was broken because bottom padding pushed the element off axis; this is now fixed