### PR TITLE
FINAP-121/multi tab support

### DIFF
--- a/ote/src/cljs/ote/app/state.cljs
+++ b/ote/src/cljs/ote/app/state.cljs
@@ -15,21 +15,19 @@
                                                   (fn [v] (.getTime v))
                                                   (fn [v] (str (.getTime v)))))
 
-(defonce app (local-storage
-               (r/atom {;; current page
-                        ;; see ote.app.routes
-                        :page :front-page
-                        :params nil ; parameters from url route
-                        :query nil ; query parameters from url (like "?foo=bar")
+(defonce app (r/atom {;; current page
+                      ;; see ote.app.routes
+                      :page :front-page
+                      :params nil ; parameters from url route
+                      :query nil ; query parameters from url (like "?foo=bar")
 
-                         :user {} ;; No user data by default
+                       :user {} ;; No user data by default
 
-                        ;; Currently selected / edited transport operator (company basic info)
-                        :transport-operator nil
+                      ;; Currently selected / edited transport operator (company basic info)
+                      :transport-operator nil
 
-                        ;; Currently selected / edited transport service
-                        :transport-service {}})
-               :nap))
+                      ;; Currently selected / edited transport service
+                      :transport-service {}}))
 
 ;; Separate app state for viewer mode
 (defonce viewer (r/atom {:loading? true

--- a/ote/src/cljs/taxiui/app/routes.cljs
+++ b/ote/src/cljs/taxiui/app/routes.cljs
@@ -1,5 +1,6 @@
 (ns taxiui.app.routes
   "Routes for the frontend app."
+  (:refer-clojure :exclude [resolve])
   (:require [bide.core :as r]
             [ote.app.state :as state]
             [ote.app.utils :refer [user-logged-in?]]
@@ -41,8 +42,13 @@
   :taxi-ui/page)
 
 (tuck/define-event ClearPageData [page]
-                   {}
-                   (update app :taxi-ui dissoc (-> (name page) keyword)))
+  {}
+  (if-not (nil? page)
+    (let [page (-> (name page) keyword)]
+      (if (some? (get-in app [:taxi-ui page]))
+        (update app :taxi-ui dissoc page)
+        app))
+    app))
 
 (defmethod on-leave-event :default [page-params]
   (->ClearPageData (:taxi-ui/page page-params)))

--- a/ote/src/cljs/taxiui/styles/front_page.cljs
+++ b/ote/src/cljs/taxiui/styles/front_page.cljs
@@ -2,7 +2,7 @@
   (:require [ote.theme.colors :as colors]
             [taxiui.theme :as theme :refer [breather-margin breather-padding grid-template-areas]]))
 
-(def info-box {})
+(def info-box {:margin-top "1.125em"})
 
 (def info-section-title (-> {:font-weight "600"}
                             breather-margin))
@@ -27,7 +27,8 @@
                           :grid-template-rows    "auto auto auto auto"
                           :gap                   "0px 0px"
                           :border                (str "0.0625em solid " colors/light-gray)
-                          :border-radius         "0.3em"}
+                          :border-radius         "0.3em"
+                          :padding               "0.25rem"}
                          (grid-template-areas ["logo price-information arrow"
                                                ". example-trip arrow"
                                                ". prices arrow"


### PR DESCRIPTION
Rollback the local storage based app state to fix multi tab support for good.

The original reason for having a local storage backed state isn't valid anymore anyways; there's not actual state we want to share between the two apps and authentication is in cookies, so everything still works as expected.