### PR TITLE
Finap 39/email reports

### DIFF
--- a/ote/src/clj/ote/authorization.clj
+++ b/ote/src/clj/ote/authorization.clj
@@ -52,7 +52,7 @@
 (defn with-transport-operator-check
   "Check that user has access (belongs to) the given transport operator.
   Runs body-fn if user has access, otherwise returns an HTTP error response and logs a warning."
-  [db user transport-operator-id body-fn]
+  [db user ^long transport-operator-id body-fn]
   (let [allowed-operators (user-transport-operators db user)
         is-admin?         (get-in user [:user :admin?])
         access-denied     #(do

--- a/ote/src/clj/ote/integration/import/gtfs.clj
+++ b/ote/src/clj/ote/integration/import/gtfs.clj
@@ -19,7 +19,8 @@
             [ote.gtfs.kalkati-to-gtfs :as kalkati-to-gtfs]
             [ote.transit-changes.detection :as detection]
             [ote.integration.report :as report])
-  (:import (java.io File)))
+  (:import (java.io File)
+           (org.apache.commons.io FilenameUtils)))
 
 (defqueries "ote/integration/import/stop_times.sql")
 (defqueries "ote/integration/import/import_gtfs.sql")
@@ -375,14 +376,14 @@
     ;; returning nil signals failure
     (when gtfs-file
       (log/debug (str "GTFS: service-id = " ts-id ", File imported and uploaded successfully, file = " filename))
-      {:gtfs-file gtfs-file
-       :gtfs-filename filename
-       :gtfs-basename (org.apache.commons.io.FilenameUtils/getBaseName filename)
+      {:gtfs-file                         gtfs-file
+       :gtfs-filename                     filename
+       :gtfs-basename                     (FilenameUtils/getBaseName filename)
        :external-interface-description-id id
-       :external-interface-data-content data-content
-       :service-id ts-id
-       :package-id (:gtfs/id (interface-latest-package db id))  ; re-fetch package to make sure we have the latest
-       :operator-name operator-name})))
+       :external-interface-data-content   data-content
+       :service-id                        ts-id
+       :package-id                        (:gtfs/id package)
+       :operator-name                     operator-name})))
 
 (defrecord GTFSImport [config]
   component/Lifecycle

--- a/ote/src/clj/ote/integration/report.clj
+++ b/ote/src/clj/ote/integration/report.clj
@@ -1,6 +1,9 @@
 (ns ote.integration.report
   "Centralized location for report logging for integration import processes"
-  (:require [specql.core :as specql]))
+  (:require [specql.core :as specql]
+            [ote.db.utils :as db-utils]))
+
+(defqueries "ote/integration/report.sql")
 
 (defn gtfs-import-report!
   [db ^String severity package-id ^String description ^bytes error]
@@ -8,3 +11,16 @@
                                           :gtfs-import/description           description
                                           :gtfs-import/error                 error
                                           :gtfs-import/severity              severity}))
+
+(defn latest-import-reports-for-all-packages
+  [db]
+  (->> (fetch-import-reports-for-latest-packages db)
+       (map (comp db-utils/underscore->structure
+                  #(update % :gtfs-import-report_error (fn [v] (String. v)))))))
+
+(defn latest-import-reports-for-service-interface
+  [db service-id interface-id]
+  (->> (fetch-latest-import-reports-for-service db {:transport-service-id              service-id
+                                                    :external-interface-description-id interface-id})
+       (map (comp db-utils/underscore->structure
+                  #(update % :gtfs-import-report_error (fn [v] (String. v)))))))

--- a/ote/src/clj/ote/integration/report.sql
+++ b/ote/src/clj/ote/integration/report.sql
@@ -1,0 +1,41 @@
+-- name: fetch-import-reports-for-latest-packages
+SELECT "gp".id                                  AS "gtfs-package_id",
+       "gp".created                             AS "gtfs-package_created",
+       "gp"."external-interface-description-id" AS "gtfs-package_external-interface-description-id",
+       "to".id                                  AS "transport-operator_id",
+       "to".name                                AS "transport-operator_name",
+       "ts".id                                  AS "transport-service_id",
+       "ts".name                                AS "transport-service_name",
+       "gir".id                                 AS "gtfs-import-report_id",
+       "gir".severity                           AS "gtfs-import-report_severity",
+       "gir".description                        AS "gtfs-import-report_description",
+       "gir".error                              AS "gtfs-import-report_error"
+  FROM "gtfs_import_report" "gir"
+           JOIN gtfs_package gp ON gir.package_id = gp.id
+           JOIN "transport-operator" "to" ON "gp"."transport-operator-id" = "to".id
+           JOIN "transport-service" "ts" ON "gp"."transport-service-id" = "ts".id
+ WHERE "gir".package_id IN (SELECT DISTINCT ON ("gp"."transport-service-id") "gp".id AS "gtfs-package_id"
+                              FROM gtfs_package "gp"
+                             ORDER BY "gp"."transport-service-id", "gp".id DESC)
+
+-- name fetch-latest-import-reports-for-service
+SELECT "gp".id                                  AS "gtfs-package_id",
+      "gp".created                             AS "gtfs-package_created",
+      "gp"."external-interface-description-id" AS "gtfs-package_external-interface-description-id",
+      "to".id                                  AS "transport-operator_id",
+      "to".name                                AS "transport-operator_name",
+      "ts".id                                  AS "transport-service_id",
+      "ts".name                                AS "transport-service_name",
+      "gir".id                                 AS "gtfs-import-report_id",
+      "gir".severity                           AS "gtfs-import-report_severity",
+      "gir".description                        AS "gtfs-import-report_description",
+      "gir".error                              AS "gtfs-import-report_error"
+ FROM "gtfs_import_report" "gir"
+          JOIN gtfs_package gp ON gir.package_id = gp.id
+          JOIN "transport-operator" "to" ON "gp"."transport-operator-id" = "to".id
+          JOIN "transport-service" "ts" ON "gp"."transport-service-id" = "ts".id
+WHERE "gir".package_id IN (SELECT DISTINCT ON ("gp"."transport-service-id") "gp".id AS "gtfs-package_id"
+                             FROM gtfs_package "gp"
+                            WHERE "gp"."transport-service-id" = :transport-service-id
+                              AND "gp"."external-interface-description-id" = :external-interface-description-id
+                            ORDER BY "gp"."transport-service-id", "gp".id DESC);

--- a/ote/src/clj/ote/main.clj
+++ b/ote/src/clj/ote/main.clj
@@ -123,7 +123,7 @@
 
    ;; Scheduled tasks
    :tasks-company (component/using (tasks-company/company-tasks) [:db])
-   :tasks-gtfs (component/using (tasks-gtfs/gtfs-tasks config) [:db])
+   :tasks-gtfs (component/using (tasks-gtfs/gtfs-tasks config) [:db :email])
    :tasks-pre-notices (component/using (tasks-pre-notices/pre-notices-tasks (:pre-notices config))
                                        [:db :email])))
 

--- a/ote/src/clj/ote/services/transit_changes.clj
+++ b/ote/src/clj/ote/services/transit_changes.clj
@@ -20,6 +20,7 @@
 
             [ote.tasks.gtfs :as gtfs-tasks]
             [ote.integration.import.gtfs :as import]
+            [ote.integration.report :as report]
             [ote.transit-changes.detection :as detection]))
 
 (defqueries "ote/services/transit_changes.sql")
@@ -122,9 +123,7 @@
 
 (defn load-gtfs-import-reports
   [db]
-  (->> (fetch-import-reports-for-latest-packages db)
-       (map (comp db-utils/underscore->structure
-                  #(update % :gtfs-import-report_error (fn [v] (String. v)))))))
+  (report/latest-import-reports-for-all-packages db))
 
 (define-service-component TransitChanges {:fields [config]}
 

--- a/ote/src/clj/ote/services/transit_changes.sql
+++ b/ote/src/clj/ote/services/transit_changes.sql
@@ -125,23 +125,3 @@ SELECT i.id, i."transport-service-id", (i."external-interface").url as url, i.fo
    AND 'route-and-schedule' = ANY(i."data-content")
    AND i."transport-service-id" = :service-id AND i.id = :interface-id
  ORDER BY id DESC;
-
--- name: fetch-import-reports-for-latest-packages
-SELECT "gp".id                                  AS "gtfs-package_id",
-       "gp".created                             AS "gtfs-package_created",
-       "gp"."external-interface-description-id" AS "gtfs-package_external-interface-description-id",
-       "to".id                                  AS "transport-operator_id",
-       "to".name                                AS "transport-operator_name",
-       "ts".id                                  AS "transport-service_id",
-       "ts".name                                AS "transport-service_name",
-       "gir".id                                 AS "gtfs-import-report_id",
-       "gir".severity                           AS "gtfs-import-report_severity",
-       "gir".description                        AS "gtfs-import-report_description",
-       "gir".error                              AS "gtfs-import-report_error"
-  FROM "gtfs_import_report" "gir"
-           JOIN gtfs_package gp ON gir.package_id = gp.id
-           JOIN "transport-operator" "to" ON "gp"."transport-operator-id" = "to".id
-           JOIN "transport-service" "ts" ON "gp"."transport-service-id" = "ts".id
- WHERE "gir".package_id IN (SELECT DISTINCT ON ("gp"."transport-service-id") "gp".id AS "gtfs-package_id"
-                              FROM gtfs_package "gp"
-                             ORDER BY "gp"."transport-service-id", "gp".id DESC)

--- a/ote/test/clj/ote/netex/netex_test.clj
+++ b/ote/test/clj/ote/netex/netex_test.clj
@@ -1,0 +1,55 @@
+(ns ote.netex.netex-test
+  (:require [clojure.test :refer :all]
+            [ote.netex.netex :as netex]))
+
+(deftest validation-report-conversion-and-reports
+  (testing "1_gtfs_csv_3 / Presence of header"
+    (is (= "transfers.txt is missing the header row"
+           (netex/netex-validation-error {:test_id "Presence of header",
+                                          :error_id "1_gtfs_csv_3",
+                                          :source {:file {:filename "transfers.txt", :line_number 1, :column_number 0}, :objectid "", :label ""},
+                                          :error_value "transfers.txt"}))))
+  (testing "1_gtfs_common_3 / Check for optional files"
+    (is (= "Optional file shapes.txt is not present."
+           (netex/netex-validation-error {:test_id "Check for optional files",
+                                          :error_id "1_gtfs_common_3",
+                                          :source {:file {:filename "shapes.txt"}, :objectid "", :label ""},
+                                          :error_value "shapes.txt"}))))
+  (testing "1_gtfs_common_4 / Presence of other files"
+    (is (= "Unexpected file contracts.txt present in GTFS package"
+           (netex/netex-validation-error {:test_id "Presence of other files",
+                                          :error_id "1_gtfs_common_4",
+                                          :source {:file {:filename "contracts.txt"}, :objectid "", :label ""},
+                                          :error_value "contracts.txt"}))))
+  (testing "1_gtfs_common_8 / Unique Identifiers"
+    (is (= "agency.txt contains the value 6791 for key agency_id multiple times, starting at line 6, column 1."
+           (netex/netex-validation-error {:test_id "Unique Identifiers",
+                                          :error_id "1_gtfs_common_8",
+                                          :source {:file {:filename "agency.txt", :line_number 6, :column_number 1}, :objectid "", :label ""},
+                                          :error_value "6791",
+                                          :reference_value "agency_id"}))))
+  (testing "1_gtfs_common_11 / Unknown columns"
+    (is (= "routes.txt contains unknown column route_sort_order"
+           (netex/netex-validation-error {:test_id "Unknown columns",
+                                          :error_id "1_gtfs_common_11",
+                                          :source {:file {:filename "routes.txt", :line_number 1, :column_number 10}, :objectid "", :label ""},
+                                          :error_value "route_sort_order"}))))
+  (testing "1_gtfs_common_12 / Data in Required columns"
+    (is (= "stop_times.txt is missing required value for column stop_id on line 9, column 4"
+           (netex/netex-validation-error {:test_id "Data in Required columns",
+                                          :error_id "1_gtfs_common_12",
+                                          :source {:file {:filename "stop_times.txt", :line_number 9, :column_number 4}, :objectid "", :label ""},
+                                          :error_value "stop_id"}))))
+  (testing "2_gtfs_stop_4 / Station without stations"
+    (is (= "stops.txt contains a station s3846 without stations at line 18, column 10"
+           (netex/netex-validation-error {:test_id "Station without stations",
+                                          :error_id "2_gtfs_stop_4",
+                                          :source {:file {:filename "stops.txt", :line_number 18, :column_number 10}, :objectid "71745", :label ""},
+                                          :error_value "s3846"}))))
+  (testing "Unknown error type will return raw data as plain string"
+    (let [error {:test_id "Teleporter endpoint temporality",
+                 :error_id "9_matter_transportation",
+                 :source {:file {:filename "quantum_gates.txt", :line_number 27, :column_number 9}, :objectid "", :label ""},
+                 :error_value "P2X-555"}]
+      (is (= (str error) (netex/netex-validation-error error))))))
+


### PR DESCRIPTION
Plumbing for sending GTFS/NeTEx validation reports as scheduled emails after nightly imports. Currently only logs the sends so that we can scope out how many emails we'd end up producing.