### PR TITLE
Improve translations for external interfaces

### DIFF
--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -67,10 +67,10 @@
    :ote.db.transport-service/location "Location"
 
    ;; External interfaces
-   :ote.db.transport-service/external-interfaces "External machine-readable interfaces"
+   :ote.db.transport-service/external-interfaces "External interfaces and API's"
    :ote.db.transport-service/data-content "Data content"
    :ote.db.transport-service/external-service-description "More info"
-   :ote.db.transport-service/external-service-url "WWW-address"
+   :ote.db.transport-service/external-service-url "URL (external API)"
    :ote.db.transport-service/booking-service "Booking service address"
    :ote.db.transport-service/rental-service "Rental service address"
    :ote.db.transport-service/format "Format"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -70,7 +70,7 @@
    :ote.db.transport-service/external-interfaces "Ulkoiset koneluettavat rajapinnat"
    :ote.db.transport-service/data-content "Tietosisältö"
    :ote.db.transport-service/external-service-description "Lisätietoja"
-   :ote.db.transport-service/external-service-url "Web-osoite"
+   :ote.db.transport-service/external-service-url "Rajapinnan URL"
    :ote.db.transport-service/booking-service "Varauspalvelun osoitetiedot"
    :ote.db.transport-service/rental-service "Vuokrauspalvelun osoitetiedot"
    :ote.db.transport-service/format "Formaatti"

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -70,7 +70,7 @@
    :ote.db.transport-service/external-interfaces "Externa maskinläsbara gränssnitt"
    :ote.db.transport-service/data-content "Informationsinnehåll"
    :ote.db.transport-service/external-service-description "Tilläggsuppgifter"
-   :ote.db.transport-service/external-service-url "WWW-adress"
+   :ote.db.transport-service/external-service-url "URL (maskinläsbara gränssnitt)"
    :ote.db.transport-service/booking-service "Bokningstjänstens adress"
    :ote.db.transport-service/rental-service "Hyrtjänstens adress"
    :ote.db.transport-service/format "Format"


### PR DESCRIPTION
Especially the Swedish translation misguided users to add alternate websites, eg. Facebook pages as external interfaces instead of actual APIs.