### PR TITLE
Fix API not sending out properly serialized response

### DIFF
--- a/ote/src/clj/ote/services/transit_changes.clj
+++ b/ote/src/clj/ote/services/transit_changes.clj
@@ -130,8 +130,9 @@
   [config db email]
   (routes
     (GET "/transit-changes/current" {user :user :as request}
-      (or (authorization/transit-authority-authorization-response user)
-          (list-current-changes db)))
+      (http/no-cache-transit-response
+        (or (authorization/transit-authority-authorization-response user)
+            (list-current-changes db))))
 
     (GET "/transit-changes/hash-calculation/" {user :user :as request}
       (when (authorization/admin? user)


### PR DESCRIPTION
This bug was caused by earlier macro unrolling, which had its own magic for handling this.