### PR TITLE
leave a trace about updating Leiningen from 2.7.1 (!!) to 2.9.10

### DIFF
--- a/aws/ansible/jenkins/tasks/leiningen.yml
+++ b/aws/ansible/jenkins/tasks/leiningen.yml
@@ -1,2 +1,2 @@
-- name: Install leiningen standalone jar
-  get_url: url=https://github.com/technomancy/leiningen/releases/download/2.7.1/leiningen-2.7.1-standalone.zip dest=/var/lib/jenkins/leiningen.jar
+- name: Install leiningen 2.9.10 standalone jar
+  get_url: url=https://codeberg.org/attachments/895a0a0d-f20d-4580-a277-e06b5eec3b6b dest=/var/lib/jenkins/leiningen.jar


### PR DESCRIPTION
The build was broken because JDK on bastion has been updated but tooling wasn't, now everything's fine again. Of course these Ansible scripts are out-of-date anyway and the actual change was done with sudo+curl, but at least this way there's a slight change someone will see this was updated.