### PR TITLE
FINAP-167: update matomo script to use Fintraffic Cloud's specific script

### DIFF
--- a/ote/src/clj/ote/services/index.clj
+++ b/ote/src/clj/ote/services/index.clj
@@ -40,23 +40,16 @@
          "  window['ga-disable-" (:tracking-code ga-conf) "'] = true; "
          "}"))))
 
-(defn matomo-analytics-scripts [config]
+(defn matomo-analytics-scripts []
   (list
     (str " <!-- Matomo -->")
     (javascript-tag
-      (str " var _paq = window._paq || [];"
-           " /* tracker methods like \"setCustomDimension\" should be called before \"trackPageView\" */"
-           " _paq.push(['setCustomUrl', 'finap.fi']);"
-           " _paq.push(['enableLinkTracking']);"
-           " _paq.push(['enableHeartBeatTimer']);"
-           " (function() {"
-           " var u=\"" (:piwik-url config) "\";"
-           " _paq.push(['setTrackerUrl', u+'piwik.php']);"
-           " _paq.push(['setSiteId', " (:site-id config) "]);"
-           " var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];"
-           " g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);"
-           " })();"
-           ))
+      (str
+        "var _mtm = window._mtm = window._mtm || [];"
+        "_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});"
+        "var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];"
+        "g.async=true; g.src='https://cdn.matomo.cloud/fintraffic.matomo.cloud/container_YeewVWCJ.js'; s.parentNode.insertBefore(g,s);"
+        ))
     (str " <!-- End Matomo Code -->")))
 
 (def favicons
@@ -109,8 +102,8 @@
                         {:integrity integrity}))])
       [:style {:id "_stylefy-constant-styles_"} ""]
       [:style {:id "_stylefy-styles_"}]
-      (when (not (true? dev-mode?))
-        (matomo-analytics-scripts matomo-config))
+      (when (not testing-env?)
+        (matomo-analytics-scripts))
       (translations localization/*language*)
       (user-info db user)]
 

--- a/ote/src/clj/ote/services/taxi_index.clj
+++ b/ote/src/clj/ote/services/taxi_index.clj
@@ -23,6 +23,18 @@
          (str "-" (:current-revision-sha (current-revision-sha))))
        ".js"))
 
+(defn matomo-analytics-scripts []
+  (list
+    (str " <!-- Matomo -->")
+    (javascript-tag
+      (str
+        "var _mtm = window._mtm = window._mtm || [];"
+        "_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});"
+        "var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];"
+        "g.async=true; g.src='https://cdn.matomo.cloud/fintraffic.matomo.cloud/container_YeewVWCJ.js'; s.parentNode.insertBefore(g,s);"
+        ))
+    (str " <!-- End Matomo Code -->")))
+
 (def favicons
   [{:rel "apple-touch-icon" :sizes "180x180" :href "/favicon/apple-touch-icon.png?v=E6jNQXq6yK"}
    {:rel "icon" :type "image/png" :sizes "32x32" :href "/favicon/favicon-32x32.png?v=E6jNQXq6yK"}
@@ -72,6 +84,8 @@
                         {:integrity integrity}))])
       [:style {:id "_stylefy-constant-styles_"} ""]
       [:style {:id "_stylefy-styles_"}]
+      (when (not testing-env?)
+        (matomo-analytics-scripts))
       (translations localization/*language*)
       (user-info db user)]
 


### PR DESCRIPTION
The script is active only in production to avoid messing with the collected data.
