### PR TITLE
disable manual piwik/matomo event generation to prevent double navigation event tracking

### DIFF
--- a/ote/src/cljs/ote/app/routes.cljs
+++ b/ote/src/cljs/ote/app/routes.cljs
@@ -169,7 +169,7 @@
                      (do
                        ; SPA page changes must be pushed to analytics script because url route might not change.
                        ;; Check tracker script in case script loading failed. A browser extension or other issue may block it.
-                       (when (exists? js/_paq)
+                       #_(when (exists? js/_paq)
                          (.push js/_paq (clj->js ["setCustomUrl", win-location]))
                          ;; trackPageView signals to matomo piwik js api a single page visit.
                          (.push js/_paq (clj->js ["trackPageView"])))


### PR DESCRIPTION
This probably made sense back in 2019 when this was originally created.
