### PR TITLE
make NeTEx export functionality rely on TIS VACO feature flag instead

### DIFF
--- a/ote/src/clj/ote/integration/export/netex.clj
+++ b/ote/src/clj/ote/integration/export/netex.clj
@@ -47,7 +47,7 @@
            db :db :as this}]
     (assoc this
       ::stop
-      (when (feature/feature-enabled? config :netex-conversion-automated)
+      (when (feature/feature-enabled? config :tis-vaco-integration)
         (http/publish! http
                        {:authenticated? false}
                        (GET "/export/netex/:transport-service-id{[0-9]+}/:file-id{[0-9]+}"


### PR DESCRIPTION
TIS VACO integration reuses the conversion result publishing functionality
