### PR TITLE
FINAP-218/add extended formats support for external interfaces

### DIFF
--- a/aws/ansible/environments/staging/group_vars/ote/vars
+++ b/aws/ansible/environments/staging/group_vars/ote/vars
@@ -5,7 +5,7 @@ testing_environment: "true"
 auth_shared_secret: "{{vault_beaker_session_secret}}"
 cookie_domain: "testi.finap.fi"
 base_url: "https://testi.finap.fi"
-flags: "#{:ote-login :ote-operators-list :sea-routes :pre-notice :gtfs-import :ote-register :service-validation :terms-of-service :other-catalogs :tis-vaco-integration}"
+flags: "#{:ote-login :ote-operators-list :sea-routes :pre-notice :gtfs-import :ote-register :service-validation :terms-of-service :other-catalogs :tis-vaco-integration :new-transit-data-formats}"
 ote_cookie_key: "{{vault_ote_cookie_key}}"
 pre_notice_attachment_bucket: "napote-pre-notice-attachment-dev"
 email_from: noreply@testi.finap.fi

--- a/ote/config.edn
+++ b/ote/config.edn
@@ -65,7 +65,8 @@
                      :service-validation
                      :terms-of-service
                      :other-catalogs
-                     :tis-vaco-integration}
+                     :tis-vaco-integration
+                     :new-transit-data-formats}
 
  :no-gtfs-update-for-operators #{}
 

--- a/ote/resources/public/language/en.edn
+++ b/ote/resources/public/language/en.edn
@@ -1009,8 +1009,18 @@ You can also draw the operating area or point to the map with drawing tools. You
  :admin-page
  {:business-id-filter {:operators "Transport operators" :services "Services" :ALL "All"}
   :published-types {:YES "Published" :NO "Not published" :ALL "All"}
-  :interface-formats {:GTFS "GTFS" :Kalkati.net "Kalkati.net" :ALL "All"}
-  :report-types {:tertile "Tertiili" :month "Kuukausi"}}
+  :interface-formats  {:GTFS        "GTFS"
+                       :GTFS-RT     "GTFS-RT"
+                       :GBFS        "GBFS"
+                       :Kalkati     "Kalkati"
+                       :Kalkati.net "Kalkati"               ; kept for legacy support
+                       :SIRI        "SIRI"
+                       :NeTEx       "NeTEx"
+                       :GeoJSON     "GeoJSON"
+                       :JSON        "JSON"
+                       :CSV         "CSV"
+                       :ALL         "All"}
+  :report-types       {:tertile "Tertiili" :month "Kuukausi"}}
 
  :transit-changes
  {:route-new "New route"

--- a/ote/resources/public/language/fi.edn
+++ b/ote/resources/public/language/fi.edn
@@ -1015,7 +1015,17 @@ Voit myös piirtää toimialueen tai toimipisteen kartan piirtotyökalujen avull
  :admin-page
  {:business-id-filter {:operators "Palveluntuottajista" :services "Palveluista" :ALL "Kaikki"}
   :published-types {:YES "Julkaistu" :NO "Julkaisematta" :ALL "Kaikki"}
-  :interface-formats {:GTFS "GTFS" :Kalkati.net "Kalkati.net" :ALL "Kaikki"}
+  :interface-formats {:GTFS        "GTFS"
+                      :GTFS-RT     "GTFS-RT"
+                      :GBFS        "GBFS"
+                      :Kalkati     "Kalkati"
+                      :Kalkati.net "Kalkati"               ; kept for legacy support
+                      :SIRI        "SIRI"
+                      :NeTEx       "NeTEx"
+                      :GeoJSON     "GeoJSON"
+                      :JSON        "JSON"
+                      :CSV         "CSV"
+                      :ALL         "Kaikki"}
   :report-types {:tertile "Tertiili" :month "Kuukausi"}}
 
  :transit-changes

--- a/ote/resources/public/language/sv.edn
+++ b/ote/resources/public/language/sv.edn
@@ -1009,7 +1009,17 @@ Tjänsterna beskrivs var för sig på egen blankett. I exemplet fyller man i bå
  :admin-page
  {:business-id-filter {:operators "Palveluntuottajista" :services "Palveluista" :ALL "Kaikki"}
   :published-types {:YES "Julkaistu" :NO "Julkaisematta" :ALL "Kaikki"}
-  :interface-formats {:GTFS "GTFS" :Kalkati.net "Kalkati.net" :ALL "Kaikki"}
+  :interface-formats {:GTFS        "GTFS"
+                      :GTFS-RT     "GTFS-RT"
+                      :GBFS        "GBFS"
+                      :Kalkati     "Kalkati"
+                      :Kalkati.net "Kalkati"               ; kept for legacy support
+                      :SIRI        "SIRI"
+                      :NeTEx       "NeTEx"
+                      :GeoJSON     "GeoJSON"
+                      :JSON        "JSON"
+                      :CSV         "CSV"
+                      :ALL         "Alla"}
   :report-types {:tertile "Tertiili" :month "Kuukausi"}}
 
  :transit-changes

--- a/ote/src/clj/ote/services/external.clj
+++ b/ote/src/clj/ote/services/external.clj
@@ -117,7 +117,8 @@
 (defn interface-type [format]
   (case format
     "GTFS" :gtfs
-    "Kalkati.net" :kalkati
+    "Kalkati" :kalkati
+    "Kalkati.net" :kalkati  ; kept for legacy support
     nil))
 
 (defn- check-external-api

--- a/ote/src/clj/ote/tasks/gtfs.clj
+++ b/ote/src/clj/ote/tasks/gtfs.clj
@@ -35,7 +35,8 @@
 (defn interface-type [format]
   (case format
     "GTFS" :gtfs
-    "Kalkati.net" :kalkati
+    "Kalkati" :kalkati
+    "Kalkati.net" :kalkati  ; kept for legacy support
     nil))
 
 (defn mark-gtfs-package-imported! [db interface]

--- a/ote/src/cljs/ote/views/admin/interfaces.cljs
+++ b/ote/src/cljs/ote/views/admin/interfaces.cljs
@@ -4,6 +4,7 @@
   (:require [cljs-react-material-ui.reagent :as ui]
             [ote.app.controller.admin :as admin-controller]
             [clojure.string :as str]
+            [ote.app.controller.flags :as flags]
             [ote.localization :refer [tr tr-key]]
             [ote.ui.common :as common-ui]
             [ote.time :as time]
@@ -112,7 +113,10 @@
           (tr [:service-search :view-routes])
           {:target "_blank"})))))
 
-(def interface-formats [:GTFS :Kalkati.net :ALL])
+(def interface-formats
+  (if (flags/enabled? :new-transit-data-formats)
+    [:GTFS :GTFS-RT :GBFS :Kalkati :SIRI :NeTEx :GeoJSON :JSON :CSV :ALL]
+    [:GTFS :Kalkati.net :ALL]))
 
 (defn interface-table-row [e! interface-id data-content operator-name format
                            import-error url date-0 imported db-error interface first? list-count selected-interface-id]

--- a/ote/src/cljs/ote/views/transport_service/transport_service_common.cljs
+++ b/ote/src/cljs/ote/views/transport_service/transport_service_common.cljs
@@ -225,7 +225,9 @@
                           {:name ::t-service/format
                            :type :autocomplete
                            :open-on-focus? true
-                           :suggestions ["GTFS" "Kalkati.net" "SIRI" "NeTEx" "GeoJSON" "JSON" "CSV"]
+                           :suggestions (if (flags/enabled? :new-transit-data-formats)
+                                          ["GTFS" "GTFS-RT" "GBFS" "Kalkati" "SIRI" "NeTEx" "GeoJSON" "JSON" "CSV"]
+                                          ["GTFS" "Kalkati.net" "SIRI" "NeTEx" "GeoJSON" "JSON" "CSV"])
                            :max-results 10
                            :label (tr [:field-labels :transport-service-common ::t-service/format])
                            :field-class "col-xs-12 col-sm-3 col-md-3"


### PR DESCRIPTION
These are for data input, logic underneath remains unchanged. In fact cunning users have already been able to set the format as whatever they please, the autofill dropdown has just held their hands well enough that they haven't.