### PR TITLE
add missing default values to netex.entur configuration

### DIFF
--- a/ote/src/cljc/ote/util/tis_configs.cljc
+++ b/ote/src/cljc/ote/util/tis_configs.cljc
@@ -12,7 +12,8 @@
 
 (defmethod base-task-names "netex" [_]
   {:validator {:name   "netex.entur"
-               :config {}}
+               :config {"codespace"     "FSR"
+                        "maximumErrors" 1000}}
    :converter {:name   "netex2gtfs.entur"
                :config {"codespace" "FSR"}}})
 


### PR DESCRIPTION
netex.entur configuration requires at least codespace and maximumErrors to be set