### PR TITLE
Use newest gtfs package in service-viewer instead of last successfull…

### DIFF
--- a/ote/src/clj/ote/netex/netex_util.clj
+++ b/ote/src/clj/ote/netex/netex_util.clj
@@ -42,7 +42,8 @@
   `config` = object which contains ote configuration properties for the environment
   `db`= ote database
   `ext-ifs-key` = A key, within a service object, which contains external interface objects collection
-  Return: collection of services with an ote-generated netex appended to those external interfaces for which a netex url is available."
+  Return: collection of services with an ote-generated netex appended to those external interfaces for which a netex url is available.
+  And update interface info with vaco status, it there is netex conversions available."
   [services config db ext-ifs-key]
   (let [conversions (fetch-conversions-for-services config db (set (map #(::t-service/id %)
                                                                         services)))]
@@ -53,17 +54,30 @@
                       (fn [interfaces]
                         (vec
                           (for [interface interfaces
-                                :let [interface-id (::t-service/id interface)]]
-                            (if-let [interface-conversion (some (fn [conversion]
-                                                                  (when (= interface-id
-                                                                           (::netex/external-interface-description-id conversion))
-                                                                    conversion))
-                                                                conversions)]
-                              (assoc interface
-                                :url-ote-netex (file-download-url config
-                                                                  (::netex/transport-service-id interface-conversion)
-                                                                  (::netex/id interface-conversion))
-                                :tis-vaco (tis-vaco/fetch-public-data db config interface-id (::netex/package_id interface-conversion)))
+                                :let [interface-id (::t-service/id interface)
+                                      service-id (::t-service/transport-service-id interface)
+                                      latest-conversion-status (first (fetch-latest-gtfs-vaco-status db {:service-id service-id
+                                                                                                         :interface-id interface-id}))
+                                      interface-conversion (some (fn [conversion]
+                                                                     (when (= interface-id
+                                                                              (::netex/external-interface-description-id conversion))
+                                                                           conversion))
+                                                                 conversions)]]
+                            (if interface-conversion
+                              (let [;; If interface-conversion package_id is the same that as last successful netex-conversion
+                                    ;; Then get latest vaco status from vaco, otherwise get vaco status from gtfs_package table.
+                                    ;; We do this to show as much information as possible to the user.
+                                    ;; And we want to prevent displaying last successful info from vaco if the validation has failed.
+                                    vaco-status (if (= (:id latest-conversion-status) (::netex/package_id interface-conversion))
+                                                  (tis-vaco/fetch-public-data db config interface-id (::netex/package_id interface-conversion))
+                                                  {:gtfs/tis-magic-link (:tis-magic-link latest-conversion-status)
+                                                   :gtfs/tis-entry-public-id (:tis-entry-public-id latest-conversion-status)
+                                                   :api-base-url (get-in config [:tis-vaco :api-base-url])})]
+                                   (assoc interface
+                                          :url-ote-netex (file-download-url config
+                                                                            (::netex/transport-service-id interface-conversion)
+                                                                            (::netex/id interface-conversion))
+                                          :tis-vaco vaco-status))
                               interface))))))
             services)
       ;; If there is not netex data, add only a vaco link to get more information
@@ -75,10 +89,10 @@
                               (for [interface interfaces
                                     :let [interface-id (::t-service/id interface)
                                           service-id (::t-service/transport-service-id interface)
-                                          latest-gtfs (first (fetch-latest-gtfs-vaco-status db {:service-id service-id
+                                          latest-conversion-status (first (fetch-latest-gtfs-vaco-status db {:service-id service-id
                                                                                                 :interface-id interface-id}))]]
                                    (assoc interface
-                                          :tis-vaco {:gtfs/tis-magic-link (:tis-magic-link latest-gtfs)
-                                                     :gtfs/tis-entry-public-id (:tis-entry-public-id latest-gtfs)
+                                          :tis-vaco {:gtfs/tis-magic-link (:tis-magic-link latest-conversion-status)
+                                                     :gtfs/tis-entry-public-id (:tis-entry-public-id latest-conversion-status)
                                                      :api-base-url (get-in config [:tis-vaco :api-base-url])}))))))
             services))))

--- a/ote/src/clj/ote/tasks/gtfs.sql
+++ b/ote/src/clj/ote/tasks/gtfs.sql
@@ -53,7 +53,7 @@ SELECT ts.id
    AND (:force = TRUE OR gtfs_should_calculate_transit_change(ts.id));
 
 -- name: fetch-latest-gtfs-vaco-status
-SELECT gp."tis-entry-public-id", gp."tis-complete", gp."tis-success", gp."tis-magic-link"
+SELECT gp.id, gp."tis-entry-public-id", gp."tis-complete", gp."tis-success", gp."tis-magic-link"
   FROM gtfs_package gp
  WHERE gp."transport-service-id" = :service-id
    AND gp."external-interface-description-id" = :interface-id


### PR DESCRIPTION
…y converted package.

This changes situation for those interfaces that are using gtfs package which is broken. If the gtfs package is ok then user won't see any changes. If the package is broken we will now display the correct status.